### PR TITLE
Remove boost from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <build_depend>mrt_cmake_modules</build_depend>
   <test_depend>gtest</test_depend>
 
-  <depend>boost</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>yaml-cpp</depend>
 


### PR DESCRIPTION
Turns out, boost is not actually being used anymore so let's remove it from the `package.xml`