### PR TITLE
Fix build issues with `std::nullopt` in gtest `EXPECT_EQ` macros.

### DIFF
--- a/test/verification.cpp
+++ b/test/verification.cpp
@@ -56,8 +56,8 @@ TEST_F(CommandVerificationTest, DefaultVerifier) {
     testPriorityArbitrator.gainControl(time);
 
     EXPECT_EQ("MidPriority", testPriorityArbitrator.getCommand(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     // LowPriority could have been verified or not, so don't test it here
 
@@ -81,8 +81,8 @@ TEST_F(CommandVerificationTest, PlaceboVerifier) {
     testPriorityArbitrator.gainControl(time);
 
     EXPECT_EQ("MidPriority", testPriorityArbitrator.getCommand(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     // LowPriority could have been verified or not, so don't test it here
 
@@ -106,8 +106,8 @@ TEST_F(CommandVerificationTest, DummyVerifierInPriorityArbitrator) {
     testPriorityArbitrator.gainControl(time);
 
     EXPECT_EQ("LowPriority", testPriorityArbitrator.getCommand(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time));
 
@@ -172,11 +172,11 @@ TEST_F(CommandVerificationTest, DummyVerifierInPriorityArbitratorWithFallback) {
     testPriorityArbitrator.gainControl(time);
 
     EXPECT_EQ("MidPriority", testPriorityArbitrator.getCommand(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testPriorityArbitrator.options().at(4)->verificationResult_.cached(time));
+    EXPECT_FALSE(testPriorityArbitrator.options().at(4)->verificationResult_.cached(time));
 
     EXPECT_FALSE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
     EXPECT_FALSE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time)->isOk());
@@ -234,8 +234,8 @@ TEST_F(CommandVerificationTest, DummyVerifierInCostArbitrator) {
     testCostArbitrator.gainControl(time);
 
     EXPECT_EQ("LowPriority", testCostArbitrator.getCommand(time));
-    EXPECT_EQ(std::nullopt, testCostArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_EQ(std::nullopt, testCostArbitrator.options().at(1)->verificationResult_.cached(time));
+    EXPECT_FALSE(testCostArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_FALSE(testCostArbitrator.options().at(1)->verificationResult_.cached(time));
     ASSERT_TRUE(testCostArbitrator.options().at(2)->verificationResult_.cached(time));
     ASSERT_TRUE(testCostArbitrator.options().at(3)->verificationResult_.cached(time));
 


### PR DESCRIPTION
gtest and `std::nullopt` don't always work well together, see #5

So, the fix is to use the `bool operator()` on our `std::optional`:

```cpp
EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
```

Runs on Ubuntu 20.04, 22.04 :ok_hand: 

Maybe that didn't work in Ubuntu18.04 or so, such that I had to do the `EXPECT_EQ` back in the ancient days…

Closes #5

Of course, testing makes more sense when combined with #4 