### PR TITLE
Add ci docker deployment

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add_ci_docker_deployment
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
The docker image is now built and pushed to ghcr.io automatically in the CI using a GitHub action.

ghcr.io has advantages over Docker Hub in that the action is able to authenticate using an automatically generated token. Additionally, organizations are not free on Docker Hub.

For good measure, the image is cross-compiled to also support ARM devices.

Before the PR, I tested the action on the dev branch and removed the dev branch trigger just before opening the PR. It's hard to test GitHub actions locally but this way I'm confident it will run on main without issues.