### PR TITLE
Fix astar virtual position

### DIFF
--- a/demo/src/astar.cpp
+++ b/demo/src/astar.cpp
@@ -36,7 +36,7 @@ int AStar::distance(const Position& start, const Position& goal) const {
         throw std::runtime_error("Can't compute distance from/to wall cell");
     }
     startCell.distanceFromStart = 0;
-    startCell.heuristic = wrappedStart.distance(wrappedGoal);
+    startCell.heuristic = computeHeuristic(startCell, wrappedGoal);
 
     openSet.push(startCell);
 


### PR DESCRIPTION
Closes https://github.com/KIT-MRT/arbitration_graphs/issues/17

This fix wraps an entities position before executing A*. If an entity is
in the virtual position outside the maze inside the tunnel, the position
is replaced by one side of the tunnel. This will cause an error in the
distance calculation by 1 but is an easy fix for what would otherwise be
an error.

One more small fix: I noticed the heuristic computation for the start cell does not consider the tunnel. I fixed that in de20640b2eccafa840d8a93b677c7079b6a09862