### PR TITLE
Change dot cluster behavior

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(Yaml-cpp REQUIRED)
 add_library(${PROJECT_NAME} STATIC
   src/astar.cpp
   src/avoid_ghost_behavior.cpp
+  src/change_dot_cluster_behavior.cpp
   src/chase_ghost_behavior.cpp
   src/cluster.cpp
   src/entities.cpp

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(${PROJECT_NAME} STATIC
   src/astar.cpp
   src/avoid_ghost_behavior.cpp
   src/chase_ghost_behavior.cpp
+  src/cluster.cpp
   src/entities.cpp
   src/environment_model.cpp
   src/random_walk_behavior.cpp

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -9,7 +9,7 @@
 namespace demo {
 
 /**
- * @brief The ChangeDotClusterBehavior makes pacman move towards the closest dot cluster
+ * @brief The ChangeDotClusterBehavior makes Pacman move towards the closest dot cluster
  * that he is not currently inside of.
  */
 class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<Command> {
@@ -25,22 +25,10 @@ public:
             : Behavior(name), environmentModel_{std::move(environmentModel)} {
     }
 
-    Command getCommand(const Time& /*time*/) override {
-        std::optional<Path> pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
-
-        if (!pathToTargetClusterCenter) {
-            throw std::runtime_error("Failed to compute path to target cluster. Can not provide a sensible command.");
-        }
-
-        return Command{pathToTargetClusterCenter.value()};
-    }
+    Command getCommand(const Time& /*time*/) override;
 
     bool checkInvocationCondition(const Time& /*time*/) const override;
-
-    bool checkCommitmentCondition(const Time& /*time*/) const override {
-        Position pacmanPosition = environmentModel_->pacmanPosition();
-        return !targetCluster_->isInCluster(pacmanPosition);
-    }
+    bool checkCommitmentCondition(const Time& /*time*/) const override;
 
     void gainControl(const Time& /*time*/) override {
         setTargetCluster();

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -9,7 +9,8 @@
 namespace demo {
 
 /**
- * @brief The ChangeDotClusterBehavior makes pacman move towards another cluster of duts.
+ * @brief The ChangeDotClusterBehavior makes pacman move towards the closest dot cluster
+ * that he is not currently inside of.
  */
 class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<Command> {
 public:
@@ -17,7 +18,7 @@ public:
     using ConstPtr = std::shared_ptr<const ChangeDotClusterBehavior>;
 
     using Cluster = utils::Cluster;
-    using Clusters = utils::ClusterFinder::Clusters;
+    using Clusters = utils::DotClusterFinder::Clusters;
 
     explicit ChangeDotClusterBehavior(EnvironmentModel::Ptr environmentModel,
                                       const std::string& name = "ChangeDotClusterBehavior")

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <arbitration_graphs/behavior.hpp>
+
+#include "environment_model.hpp"
+#include "types.hpp"
+#include "utils/cluster.hpp"
+
+namespace demo {
+
+/**
+ * @brief The ChangeDotClusterBehavior makes pacman move towards another cluster of duts.
+ */
+class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<Command> {
+public:
+    using Ptr = std::shared_ptr<ChangeDotClusterBehavior>;
+    using ConstPtr = std::shared_ptr<const ChangeDotClusterBehavior>;
+
+    using Cluster = utils::Cluster;
+    using Clusters = utils::ClusterFinder::Clusters;
+
+    explicit ChangeDotClusterBehavior(EnvironmentModel::Ptr environmentModel,
+                                      const std::string& name = "ChangeDotClusterBehavior")
+            : Behavior(name), environmentModel_{std::move(environmentModel)} {
+    }
+
+    Command getCommand(const Time& /*time*/) override {
+        Path pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
+        return Command{pathToTargetClusterCenter};
+    }
+
+    bool checkInvocationCondition(const Time& /*time*/) const override;
+
+    bool checkCommitmentCondition(const Time& /*time*/) const override {
+        Position pacmanPosition = environmentModel_->pacmanPosition();
+        return !targetCluster_->isInCluster(pacmanPosition);
+    }
+
+    void gainControl(const Time& /*time*/) override {
+        setTargetCluster();
+    }
+    void loseControl(const Time& /*time*/) override {
+        targetCluster_.reset();
+    }
+
+private:
+    void setTargetCluster();
+
+    std::optional<Cluster> targetCluster_;
+    EnvironmentModel::Ptr environmentModel_;
+};
+
+} // namespace demo

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -26,8 +26,13 @@ public:
     }
 
     Command getCommand(const Time& /*time*/) override {
-        Path pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
-        return Command{pathToTargetClusterCenter};
+        std::optional<Path> pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
+
+        if (!pathToTargetClusterCenter) {
+            throw std::runtime_error("Failed to compute path to target cluster. Can not provide a sensible command.");
+        }
+
+        return Command{pathToTargetClusterCenter.value()};
     }
 
     bool checkInvocationCondition(const Time& /*time*/) const override;

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -92,6 +92,10 @@ public:
         return astar_.mazeDistance(start, goal);
     }
 
+    Path pathTo(const Position& goal) {
+        return astar_.shortestPath(pacmanPosition(), goal);
+    }
+
     std::optional<Path> pathToClosestDot(const Position& position) const {
         return astar_.pathToClosestDot(position);
     }

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -103,6 +103,9 @@ public:
     bool isWall(const Position& position) const {
         return maze_->isWall(position);
     }
+    Position positionConsideringTunnel(const Position& position) const {
+        return maze_->positionConsideringTunnel(position);
+    }
 
 protected:
     void updateEntities(const entt::Registry& registry);

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -92,7 +92,7 @@ public:
         return astar_.mazeDistance(start, goal);
     }
 
-    Path pathTo(const Position& goal) {
+    std::optional<Path> pathTo(const Position& goal) {
         return astar_.shortestPath(pacmanPosition(), goal);
     }
 

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -74,8 +74,9 @@ public:
     /**
      * @brief Returns a vector of dots representing the centers of all dot clusters.
      *
-     * A dot cluster is a set of dots that can be connected by a path passing through neither walls nor empty space.
-     * The center of a cluster is the dot closest to the average position of all dots of the cluster.
+     * A dot cluster is a set of dots (including power pellets) that can be connected by a path passing through neither
+     * walls nor empty space. The center of a cluster is the dot closest to the average position of all dots of the
+     * cluster.
      */
     Positions dotClusterCenters() const {
         return clusterFinder_.dotClusterCenters();

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -21,7 +21,7 @@ namespace demo {
 class EnvironmentModel {
 public:
     using Cluster = utils::Cluster;
-    using Clusters = utils::ClusterFinder::Clusters;
+    using Clusters = utils::DotClusterFinder::Clusters;
     using Entities = utils::Entities;
     using Maze = utils::Maze;
     using Ghost = utils::Ghost;
@@ -46,7 +46,7 @@ public:
     void update(const Game& game) {
         maze_ = std::make_shared<Maze>(game.maze);
         astar_.updateMaze(maze_);
-        clusterFinder_ = utils::ClusterFinder{maze_};
+        clusterFinder_ = utils::DotClusterFinder{maze_};
         updateEntities(game.reg);
     }
 
@@ -80,7 +80,7 @@ public:
      * walls nor empty space.
      */
     Clusters dotCluster() const {
-        return clusterFinder_.dotClusters();
+        return clusterFinder_.clusters();
     }
 
     /**
@@ -116,7 +116,7 @@ protected:
     Maze::ConstPtr maze_;
 
     utils::AStar astar_;
-    utils::ClusterFinder clusterFinder_;
+    utils::DotClusterFinder clusterFinder_;
     mutable util_caching::Cache<Time, GhostWithDistance> closestGhostCache_;
     mutable util_caching::Cache<Time, GhostWithDistance> closestScaredGhostCache_;
 };

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -20,6 +20,8 @@ namespace demo {
  * the world. */
 class EnvironmentModel {
 public:
+    using Cluster = utils::Cluster;
+    using Clusters = utils::ClusterFinder::Clusters;
     using Entities = utils::Entities;
     using Maze = utils::Maze;
     using Ghost = utils::Ghost;
@@ -72,14 +74,13 @@ public:
     std::optional<GhostWithDistance> closestScaredGhost(const Time& time) const;
 
     /**
-     * @brief Returns a vector of dots representing the centers of all dot clusters.
+     * @brief Returns a vector of all dot clusters.
      *
      * A dot cluster is a set of dots (including power pellets) that can be connected by a path passing through neither
-     * walls nor empty space. The center of a cluster is the dot closest to the average position of all dots of the
-     * cluster.
+     * walls nor empty space.
      */
-    Positions dotClusterCenters() const {
-        return clusterFinder_.dotClusterCenters();
+    Clusters dotCluster() const {
+        return clusterFinder_.dotClusters();
     }
 
     /**

--- a/demo/include/demo/pacman_agent.hpp
+++ b/demo/include/demo/pacman_agent.hpp
@@ -3,6 +3,7 @@
 #include <arbitration_graphs/priority_arbitrator.hpp>
 
 #include "avoid_ghost_behavior.hpp"
+#include "change_dot_cluster_behavior.hpp"
 #include "chase_ghost_behavior.hpp"
 #include "eat_closest_dot_behavior.hpp"
 #include "environment_model.hpp"
@@ -34,6 +35,7 @@ public:
         environmentModel_ = std::make_shared<EnvironmentModel>(game);
 
         avoidGhostBehavior_ = std::make_shared<AvoidGhostBehavior>(environmentModel_, parameters_.avoidGhostBehavior);
+        changeDotClusterBehavior_ = std::make_shared<ChangeDotClusterBehavior>(environmentModel_);
         chaseGhostBehavior_ = std::make_shared<ChaseGhostBehavior>(environmentModel_, parameters_.chaseGhostBehavior);
         eatClosestDotBehavior_ = std::make_shared<EatClosestDotBehavior>(environmentModel_);
         randomWalkBehavior_ = std::make_shared<RandomWalkBehavior>(parameters_.randomWalkBehavior);
@@ -42,6 +44,7 @@ public:
         rootArbitrator_ = std::make_shared<PriorityArbitrator>();
         rootArbitrator_->addOption(chaseGhostBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(avoidGhostBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
+        rootArbitrator_->addOption(changeDotClusterBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(eatClosestDotBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(randomWalkBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(stayInPlaceBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
@@ -69,6 +72,7 @@ private:
     Parameters parameters_;
 
     AvoidGhostBehavior::Ptr avoidGhostBehavior_;
+    ChangeDotClusterBehavior::Ptr changeDotClusterBehavior_;
     ChaseGhostBehavior::Ptr chaseGhostBehavior_;
     EatClosestDotBehavior::Ptr eatClosestDotBehavior_;
     RandomWalkBehavior::Ptr randomWalkBehavior_;

--- a/demo/include/utils/astar.hpp
+++ b/demo/include/utils/astar.hpp
@@ -95,12 +95,6 @@ private:
         return std::min(cell.manhattanDistance(goal), maze_->width() - cell.manhattanDistance(goal));
     }
 
-    /**
-     * @brief If we are about to step of the maze and the opposite end is passable as well,
-     * we assume they are connected by a tunnel and adjust the position accordingly.
-     */
-    Position positionConsideringTunnel(const Position& position) const;
-
     Maze::ConstPtr maze_;
     mutable util_caching::Cache<std::pair<Position, Position>, int> distanceCache_;
 };

--- a/demo/include/utils/astar.hpp
+++ b/demo/include/utils/astar.hpp
@@ -60,7 +60,7 @@ public:
     /**
      * @brief Returns the shortest path from the start to the goal position considering the maze geometry.
      */
-    Path shortestPath(const Position& start, const Position& goal) const;
+    std::optional<Path> shortestPath(const Position& start, const Position& goal) const;
 
     /**
      * @brief Returns the path from a given start position to the closest dot.
@@ -82,7 +82,7 @@ private:
      * Will expand the path backwards until no more predecessor relationship is available. If the cell at the goal
      * position does not have a predecessor, the path will be empty.
      */
-    Path pathTo(const AStarMazeAdapter& maze, const Position& goal) const;
+    Path extractPathTo(const AStarMazeAdapter& maze, const Position& goal) const;
 
     /**
      * @brief Approximates the distance of a given cell to a goal while considering a shortcut via the tunnel.

--- a/demo/include/utils/astar.hpp
+++ b/demo/include/utils/astar.hpp
@@ -1,40 +1,36 @@
 #pragma once
 
 #include <limits>
-#include <memory>
 #include <optional>
 #include <queue>
 #include <utility>
 #include <vector>
 
-#include <comp/position.hpp>
 #include <util_caching/cache.hpp>
-#include <pacman/util/grid.hpp>
 
 #include "demo/types.hpp"
 #include "utils/maze.hpp"
 
 namespace utils {
 
-using Move = demo::Move;
 using Path = demo::Path;
 using Position = demo::Position;
 using TileType = demo::TileType;
 
-struct Cell {
+struct AStarCell : public BaseCell {
+    using Move = demo::Move;
+
     struct CompareCells {
-        bool operator()(const Cell& left, const Cell& right) {
+        bool operator()(const AStarCell& left, const AStarCell& right) {
             return (left.distanceFromStart + left.heuristic) > (right.distanceFromStart + right.heuristic);
         }
     };
 
-    Cell(const Position& position, const TileType& type) : position(position), type(type) {};
+    AStarCell(const Position& position, const TileType& type) : BaseCell(position, type) {};
 
-    Position position;
+    bool visited{false};
     int distanceFromStart{std::numeric_limits<int>::max()};
     double heuristic{std::numeric_limits<int>::max()};
-    bool visited{false};
-    TileType type;
     std::optional<Move> moveFromPredecessor;
 
     double manhattanDistance(const Position& other) const {
@@ -42,29 +38,12 @@ struct Cell {
     }
 };
 
-class MazeAdapter {
-public:
-    using MazeStateConstPtr = std::shared_ptr<const MazeState>;
-
-    explicit MazeAdapter(Maze::ConstPtr maze) : maze_(std::move(maze)), cells_({maze_->width(), maze_->height()}) {};
-
-    Cell& cell(const Position& position) const {
-        if (!cells_[{position.x, position.y}]) {
-            cells_[{position.x, position.y}] = Cell(position, maze_->at(position));
-        }
-
-        return cells_[{position.x, position.y}].value();
-    }
-
-private:
-    Maze::ConstPtr maze_;
-    mutable Grid<std::optional<Cell>> cells_;
-};
-
 class AStar {
 public:
-    using HeuristicFunction = std::function<int(const Cell&)>;
-    using Set = std::priority_queue<Cell, std::vector<Cell>, Cell::CompareCells>;
+    using AStarMazeAdapter = MazeAdapter<AStarCell>;
+    using Cell = AStarCell;
+    using HeuristicFunction = std::function<int(const AStarCell&)>;
+    using Set = std::priority_queue<AStarCell, std::vector<AStarCell>, AStarCell::CompareCells>;
 
     constexpr static int NoPathFound = std::numeric_limits<int>::max();
 
@@ -95,7 +74,7 @@ public:
     }
 
 private:
-    void expandCell(Set& openSet, MazeAdapter& mazeAdapter, const HeuristicFunction& heuristic) const;
+    void expandCell(Set& openSet, AStarMazeAdapter& mazeAdapter, const HeuristicFunction& heuristic) const;
 
     /**
      * @brief Create a path by traversing predecessor relationships up to a goal position.
@@ -103,7 +82,7 @@ private:
      * Will expand the path backwards until no more predecessor relationship is available. If the cell at the goal
      * position does not have a predecessor, the path will be empty.
      */
-    Path pathTo(const MazeAdapter& maze, const Position& goal) const;
+    Path pathTo(const AStarMazeAdapter& maze, const Position& goal) const;
 
     /**
      * @brief Approximates the distance of a given cell to a goal while considering a shortcut via the tunnel.

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -22,6 +22,9 @@ struct Cluster {
     explicit Cluster(const int& clusterId, const std::vector<Position>& dots)
             : id(clusterId), dots(dots), center{findClusterCenter()} {
     }
+    bool isInCluster(const Position& target) const {
+        return std::any_of(dots.begin(), dots.end(), [target](Position dot) { return dot == target; });
+    }
 
     int id;
     std::vector<Position> dots;

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "demo/types.hpp"
+#include "utils/maze.hpp"
+
+namespace utils {
+
+using Path = demo::Path;
+using Position = demo::Position;
+using TileType = demo::TileType;
+
+struct ClusterCell : public BaseCell {
+    ClusterCell(const Position& position, const TileType& type) : BaseCell(position, type) {};
+
+    bool visited{false};
+};
+
+struct Cluster {
+    explicit Cluster(int clusterId) : id(clusterId) {
+    }
+
+    int id;
+    std::vector<Position> dots;
+};
+
+class ClusterFinder {
+public:
+    using ClusterMazeAdapter = MazeAdapter<ClusterCell>;
+    using Cell = ClusterCell;
+    explicit ClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)) {
+    }
+
+    std::vector<Cluster> findDotClusters() const;
+
+private:
+    Cluster expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter, const int& clusterID) const;
+
+    Maze::ConstPtr maze_;
+};
+
+} // namespace utils

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -18,33 +18,39 @@ struct ClusterCell : public BaseCell {
     bool visited{false};
 };
 
+/**
+ * @brief A cluster is defined by a set of points that can be connected by a path which passes through neither walls nor
+ * empty space.
+ */
 struct Cluster {
-    explicit Cluster(const int& clusterId, const std::vector<Position>& dots)
-            : id(clusterId), dots(dots), center{findClusterCenter()} {
+    explicit Cluster(const int& clusterId, const std::vector<Position>& points)
+            : id(clusterId), dots(points), center{findClusterCenter()} {
     }
     bool isInCluster(const Position& target) const {
         return std::any_of(dots.begin(), dots.end(), [target](Position dot) { return dot == target; });
     }
 
     int id;
-    std::vector<Position> dots;
+    Positions dots;
 
-    /// @brief The dot closest to the average position of all the dots of this cluster
-    Position center;
+    Position center; ///< The dot closest to the average position of all the dots of this cluster
 
 private:
     Position findClusterCenter() const;
 };
 
-class ClusterFinder {
+/**
+ * @brief Search and store all clusters of dots (including power pellets) given the maze state.
+ */
+class DotClusterFinder {
 public:
+    using Cell = ClusterCell;
     using Clusters = std::vector<Cluster>;
     using ClusterMazeAdapter = MazeAdapter<ClusterCell>;
-    using Cell = ClusterCell;
 
-    explicit ClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)), clusters_{findDotClusters()} {
+    explicit DotClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)), clusters_{findDotClusters()} {
     }
-    Clusters dotClusters() const {
+    Clusters clusters() const {
         return clusters_;
     }
 

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -23,7 +23,7 @@ struct ClusterCell : public BaseCell {
  * empty space.
  */
 struct Cluster {
-    explicit Cluster(const int& clusterId, const std::vector<Position>& points)
+    explicit Cluster(const int& clusterId, const Positions& points)
             : id(clusterId), dots(points), center{findClusterCenter()} {
     }
     bool isInCluster(const Position& target) const {

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -34,17 +34,24 @@ private:
 
 class ClusterFinder {
 public:
+    using Clusters = std::vector<Cluster>;
     using ClusterMazeAdapter = MazeAdapter<ClusterCell>;
     using Cell = ClusterCell;
-    explicit ClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)) {
-    }
 
-    std::vector<Cluster> findDotClusters() const;
+    explicit ClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)), clusters_{findDotClusters()} {
+    }
+    Clusters clusters() const {
+        return clusters_;
+    }
+    std::vector<Position> clusterCenters() const;
+
 
 private:
     std::vector<Position> expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const;
+    Clusters findDotClusters() const;
 
     Maze::ConstPtr maze_;
+    Clusters clusters_;
 };
 
 } // namespace utils

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -9,6 +9,7 @@ namespace utils {
 
 using Path = demo::Path;
 using Position = demo::Position;
+using Positions = demo::Positions;
 using TileType = demo::TileType;
 
 struct ClusterCell : public BaseCell {
@@ -43,11 +44,11 @@ public:
     Clusters clusters() const {
         return clusters_;
     }
-    std::vector<Position> clusterCenters() const;
+    Positions clusterCenters() const;
 
 
 private:
-    std::vector<Position> expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const;
+    Positions expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const;
     Clusters findDotClusters() const;
 
     Maze::ConstPtr maze_;

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -41,10 +41,10 @@ public:
 
     explicit ClusterFinder(Maze::ConstPtr maze) : maze_(std::move(maze)), clusters_{findDotClusters()} {
     }
-    Clusters clusters() const {
+    Clusters dotClusters() const {
         return clusters_;
     }
-    Positions clusterCenters() const;
+    Positions dotClusterCenters() const;
 
 
 private:

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "demo/types.hpp"
 #include "utils/maze.hpp"
 
@@ -16,11 +18,18 @@ struct ClusterCell : public BaseCell {
 };
 
 struct Cluster {
-    explicit Cluster(int clusterId) : id(clusterId) {
+    explicit Cluster(const int& clusterId, const std::vector<Position>& dots)
+            : id(clusterId), dots(dots), center{findClusterCenter()} {
     }
 
     int id;
     std::vector<Position> dots;
+
+    /// @brief The dot closest to the average position of all the dots of this cluster
+    Position center;
+
+private:
+    Position findClusterCenter() const;
 };
 
 class ClusterFinder {
@@ -33,7 +42,7 @@ public:
     std::vector<Cluster> findDotClusters() const;
 
 private:
-    Cluster expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter, const int& clusterID) const;
+    std::vector<Position> expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const;
 
     Maze::ConstPtr maze_;
 };

--- a/demo/include/utils/cluster.hpp
+++ b/demo/include/utils/cluster.hpp
@@ -44,8 +44,6 @@ public:
     Clusters dotClusters() const {
         return clusters_;
     }
-    Positions dotClusterCenters() const;
-
 
 private:
     Positions expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const;

--- a/demo/include/utils/maze.hpp
+++ b/demo/include/utils/maze.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <utility>
+
 #include <pacman/core/maze.hpp>
 
 #include "demo/types.hpp"
@@ -53,6 +55,41 @@ private:
         {demo::entt::Tile::wall, TileType::WALL},
         {demo::entt::Tile::door, TileType::DOOR},
     };
+};
+
+struct BaseCell {
+    using TileType = demo::TileType;
+    using Position = demo::Position;
+
+    BaseCell(const Position& position, const TileType& type) : position(position), type(type) {};
+
+    double manhattanDistance(const Position& other) const {
+        return std::abs(position.x - other.x) + std::abs(position.y - other.y);
+    }
+
+    Position position;
+    TileType type;
+};
+
+template <typename CellType>
+class MazeAdapter {
+public:
+    using MazeStateConstPtr = std::shared_ptr<const MazeState>;
+    using Position = demo::Position;
+
+    explicit MazeAdapter(Maze::ConstPtr maze) : maze_(std::move(maze)), cells_({maze_->width(), maze_->height()}) {};
+
+    CellType& cell(const Position& position) const {
+        if (!cells_[{position.x, position.y}]) {
+            cells_[{position.x, position.y}] = CellType(position, maze_->operator[](position));
+        }
+
+        return cells_[{position.x, position.y}].value();
+    }
+
+private:
+    Maze::ConstPtr maze_;
+    mutable Grid<std::optional<CellType>> cells_;
 };
 
 } // namespace utils

--- a/demo/include/utils/maze.hpp
+++ b/demo/include/utils/maze.hpp
@@ -101,9 +101,9 @@ struct BaseCell {
  * @brief Adapter class for storing properties per cell of the underlying maze.
  *
  * The MazeAdapter is a helpful little class to put between an algorithm and the actual maze class. It can be used to
- * store properties per cell of the maze grid using the templated CellType class. Cells are lazily initialized.
+ * store properties per cell of the maze grid using the templated CellT class. Cells are lazily initialized.
  */
-template <typename CellType = BaseCell>
+template <typename CellT = BaseCell>
 class MazeAdapter {
 public:
     using MazeStateConstPtr = std::shared_ptr<const MazeState>;
@@ -111,9 +111,9 @@ public:
 
     explicit MazeAdapter(Maze::ConstPtr maze) : maze_(std::move(maze)), cells_({maze_->width(), maze_->height()}) {};
 
-    CellType& cell(const Position& position) const {
+    CellT& cell(const Position& position) const {
         if (!cells_[{position.x, position.y}]) {
-            cells_[{position.x, position.y}] = CellType(position, maze_->operator[](position));
+            cells_[{position.x, position.y}] = CellT(position, maze_->operator[](position));
         }
 
         return cells_[{position.x, position.y}].value();
@@ -121,7 +121,7 @@ public:
 
 private:
     Maze::ConstPtr maze_;
-    mutable Grid<std::optional<CellType>> cells_;
+    mutable Grid<std::optional<CellT>> cells_;
 };
 
 } // namespace utils

--- a/demo/include/utils/maze.hpp
+++ b/demo/include/utils/maze.hpp
@@ -9,6 +9,21 @@
 
 namespace utils {
 
+/**
+ * @brief Computes the modulus of a given numerator and denominator, ensuring a non-negative result when the denominator
+ * is positive.
+ *
+ * This function calculates the result of the modulus operation. If the denominator is positive, the result is
+ * non-negative and in the range [0, denominator - 1].
+ *
+ * @param numerator The value to be divided (dividend).
+ * @param denominator The value by which the numerator is divided (divisor).
+ * @return An integer representing the modulus of the division.
+ */
+inline int nonNegativeModulus(const int& numerator, const int& denominator) {
+    return (denominator + (numerator % denominator)) % denominator;
+}
+
 class Maze {
 public:
     using MazeState = demo::entt::MazeState;
@@ -34,6 +49,14 @@ public:
     }
     int height() const {
         return mazeState_.height();
+    }
+
+    Position positionConsideringTunnel(const Position& position) const {
+        Position wrappedPosition{nonNegativeModulus(position.x, width()), nonNegativeModulus(position.y, height())};
+        if (isPassableCell(wrappedPosition)) {
+            return wrappedPosition;
+        }
+        return position;
     }
 
     bool isWall(const Position& position) const {

--- a/demo/include/utils/maze.hpp
+++ b/demo/include/utils/maze.hpp
@@ -97,7 +97,13 @@ struct BaseCell {
     TileType type;
 };
 
-template <typename CellType>
+/**
+ * @brief Adapter class for storing properties per cell of the underlying maze.
+ *
+ * The MazeAdapter is a helpful little class to put between an algorithm and the actual maze class. It can be used to
+ * store properties per cell of the maze grid using the templated CellType class. Cells are lazily initialized.
+ */
+template <typename CellType = BaseCell>
 class MazeAdapter {
 public:
     using MazeStateConstPtr = std::shared_ptr<const MazeState>;

--- a/demo/include/utils/maze.hpp
+++ b/demo/include/utils/maze.hpp
@@ -89,6 +89,9 @@ struct BaseCell {
     double manhattanDistance(const Position& other) const {
         return std::abs(position.x - other.x) + std::abs(position.y - other.y);
     }
+    bool isConsumable() const {
+        return type == TileType::DOT || type == TileType::ENGERIZER;
+    }
 
     Position position;
     TileType type;

--- a/demo/src/astar.cpp
+++ b/demo/src/astar.cpp
@@ -36,7 +36,7 @@ Path AStar::shortestPath(const Position& start, const Position& goal) const {
     Position wrappedStart = positionConsideringTunnel(start);
     Position wrappedGoal = positionConsideringTunnel(goal);
 
-    MazeAdapter mazeAdapter(maze_);
+    AStarMazeAdapter mazeAdapter(maze_);
     Set openSet;
 
     Cell& startCell = mazeAdapter.cell(wrappedStart);
@@ -68,7 +68,7 @@ std::optional<Path> AStar::pathToClosestDot(const Position& start) const {
     // tunnel.
     Position wrappedStart = positionConsideringTunnel(start);
 
-    MazeAdapter mazeAdapter(maze_);
+    AStarMazeAdapter mazeAdapter(maze_);
     Set openSet;
 
     Cell& startCell = mazeAdapter.cell(wrappedStart);
@@ -93,7 +93,7 @@ std::optional<Path> AStar::pathToClosestDot(const Position& start) const {
     return {};
 }
 
-void AStar::expandCell(Set& openSet, MazeAdapter& mazeAdapter, const HeuristicFunction& heuristic) const {
+void AStar::expandCell(Set& openSet, AStarMazeAdapter& mazeAdapter, const HeuristicFunction& heuristic) const {
     Cell current = openSet.top();
     openSet.pop();
 
@@ -123,7 +123,7 @@ void AStar::expandCell(Set& openSet, MazeAdapter& mazeAdapter, const HeuristicFu
     }
 }
 
-Path AStar::pathTo(const MazeAdapter& maze, const Position& goal) const {
+Path AStar::pathTo(const AStarMazeAdapter& maze, const Position& goal) const {
     Path path;
     Cell current = maze.cell(goal);
     while (current.moveFromPredecessor) {

--- a/demo/src/avoid_ghost_behavior.cpp
+++ b/demo/src/avoid_ghost_behavior.cpp
@@ -10,7 +10,7 @@ Command AvoidGhostBehavior::getCommand(const Time& time) {
 
     double maxDistance = -1;
     for (const auto& move : Move::possibleMoves()) {
-        auto nextPosition = pacmanPosition + move.deltaPosition;
+        auto nextPosition = environmentModel_->positionConsideringTunnel(pacmanPosition + move.deltaPosition);
 
         if (environmentModel_->isWall(nextPosition)) {
             continue;

--- a/demo/src/change_dot_cluster_behavior.cpp
+++ b/demo/src/change_dot_cluster_behavior.cpp
@@ -2,6 +2,16 @@
 
 namespace demo {
 
+Command ChangeDotClusterBehavior::getCommand(const Time& /*time*/) {
+    std::optional<Path> pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
+
+    if (!pathToTargetClusterCenter) {
+        throw std::runtime_error("Failed to compute path to target cluster. Can not provide a sensible command.");
+    }
+
+    return Command{pathToTargetClusterCenter.value()};
+}
+
 bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/) const {
     auto pacmanPosition = environmentModel_->pacmanPosition();
     Clusters clusters = environmentModel_->dotCluster();
@@ -16,6 +26,11 @@ bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/) co
     }
 
     return true;
+}
+
+bool ChangeDotClusterBehavior::checkCommitmentCondition(const Time& /*time*/) const {
+    Position pacmanPosition = environmentModel_->pacmanPosition();
+    return !targetCluster_->isInCluster(pacmanPosition);
 }
 
 void ChangeDotClusterBehavior::setTargetCluster() {

--- a/demo/src/change_dot_cluster_behavior.cpp
+++ b/demo/src/change_dot_cluster_behavior.cpp
@@ -1,0 +1,35 @@
+#include "demo/change_dot_cluster_behavior.hpp"
+
+namespace demo {
+
+bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/) const {
+    auto pacmanPosition = environmentModel_->pacmanPosition();
+    Clusters clusters = environmentModel_->dotCluster();
+
+    if (clusters.empty()) {
+        // We cannot navigate to a cluster if there aren't any
+        return false;
+    }
+    if (clusters.size() == 1 && clusters.front().isInCluster(pacmanPosition)) {
+        // The only cluster left is the one we are already in
+        return false;
+    }
+
+    return true;
+}
+
+void ChangeDotClusterBehavior::setTargetCluster() {
+    auto pacmanPosition = environmentModel_->pacmanPosition();
+    Clusters clusters = environmentModel_->dotCluster();
+
+    int minDistance = std::numeric_limits<int>::max();
+    for (const auto& cluster : clusters) {
+        int distance = environmentModel_->mazeDistance(pacmanPosition, cluster.center);
+        if (distance < minDistance && !cluster.isInCluster(pacmanPosition)) {
+            minDistance = distance;
+            targetCluster_ = cluster;
+        }
+    }
+}
+
+} // namespace demo

--- a/demo/src/chase_ghost_behavior.cpp
+++ b/demo/src/chase_ghost_behavior.cpp
@@ -15,7 +15,7 @@ Command ChaseGhostBehavior::getCommand(const Time& time) {
 
     double minDistance = std::numeric_limits<double>::max();
     for (const auto& move : Move::possibleMoves()) {
-        auto nextPosition = pacmanPosition + move.deltaPosition;
+        auto nextPosition = environmentModel_->positionConsideringTunnel(pacmanPosition + move.deltaPosition);
 
         if (environmentModel_->isWall(nextPosition)) {
             continue;

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -50,7 +50,7 @@ ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
             Position start{column, row};
             ClusterCell& startCell = mazeAdapter.cell(start);
 
-            if (startCell.type != TileType::DOT || startCell.visited) {
+            if (!startCell.isConsumable() || startCell.visited) {
                 continue;
             }
             Positions dots = expandDot(startCell, mazeAdapter);
@@ -86,7 +86,7 @@ Positions ClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& 
             }
             ClusterCell& neighbor = mazeAdapter.cell(nextPosition);
 
-            if (neighbor.type == TileType::DOT && !neighbor.visited) {
+            if (neighbor.isConsumable() && !neighbor.visited) {
                 bfsQueue.push(nextPosition);
             }
         }

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -9,9 +9,9 @@ Position Cluster::findClusterCenter() const {
     int sumX = 0;
     int sumY = 0;
 
-    for (const auto& dot : dots) {
-        sumX += dot.x;
-        sumY += dot.y;
+    for (const auto& point : dots) {
+        sumX += point.x;
+        sumY += point.y;
     }
 
     int avgX = std::floor(sumX / dots.size());
@@ -32,7 +32,7 @@ Position Cluster::findClusterCenter() const {
     return closestDot;
 }
 
-ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
+DotClusterFinder::Clusters DotClusterFinder::findDotClusters() const {
     ClusterMazeAdapter mazeAdapter(maze_);
     Clusters clusters;
     int clusterId = 0;
@@ -52,7 +52,7 @@ ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
     return clusters;
 }
 
-Positions ClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const {
+Positions DotClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const {
     Positions dots;
 
     std::queue<Position> bfsQueue;

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -32,14 +32,6 @@ Position Cluster::findClusterCenter() const {
     return closestDot;
 }
 
-Positions ClusterFinder::dotClusterCenters() const {
-    Positions centerDots;
-    for (const auto& cluster : clusters_) {
-        centerDots.push_back(cluster.center);
-    }
-    return centerDots;
-}
-
 ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
     ClusterMazeAdapter mazeAdapter(maze_);
     Clusters clusters;

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -1,0 +1,62 @@
+#include "utils/cluster.hpp"
+
+#include <queue>
+
+namespace utils {
+
+std::vector<Cluster> ClusterFinder::findDotClusters() const {
+    ClusterMazeAdapter mazeAdapter(maze_);
+    std::vector<Cluster> clusters;
+    int clusterId = 0;
+
+    for (int row = 0; row < maze_->height(); row++) {
+        for (int column = 0; column < maze_->width(); column++) {
+            Position start{column, row};
+            ClusterCell& startCell = mazeAdapter.cell(start);
+
+            if (startCell.type != TileType::DOT || startCell.visited) {
+                continue;
+            }
+            Cluster cluster = expandDot(startCell, mazeAdapter, clusterId++);
+            clusters.push_back(cluster);
+        }
+    }
+    return clusters;
+}
+
+Cluster ClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter, const int& clusterID) const {
+    Cluster cluster(clusterID);
+
+    std::queue<Position> bfsQueue;
+    bfsQueue.push(start.position);
+
+    while (!bfsQueue.empty()) {
+        Position currentPosition = bfsQueue.front();
+        bfsQueue.pop();
+        ClusterCell& current = mazeAdapter.cell(currentPosition);
+
+        if (current.visited) {
+            continue;
+        }
+        current.visited = true;
+        cluster.dots.push_back(currentPosition);
+
+        for (const auto& move : demo::Move::possibleMoves()) {
+            Position nextPosition = currentPosition + move.deltaPosition;
+            nextPosition = maze_->positionConsideringTunnel(nextPosition);
+
+            if (!maze_->isPassableCell(nextPosition)) {
+                continue;
+            }
+            ClusterCell& neighbor = mazeAdapter.cell(nextPosition);
+
+            if (neighbor.type == TileType::DOT && !neighbor.visited) {
+                bfsQueue.push(nextPosition);
+            }
+        }
+    }
+
+    return cluster;
+}
+
+} // namespace utils

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -32,10 +32,17 @@ Position Cluster::findClusterCenter() const {
     return closestDot;
 }
 
+std::vector<Position> ClusterFinder::clusterCenters() const {
+    std::vector<Position> centerDots;
+    for (const auto& cluster : clusters_) {
+        centerDots.push_back(cluster.center);
+    }
+    return centerDots;
+}
 
-std::vector<Cluster> ClusterFinder::findDotClusters() const {
+ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
     ClusterMazeAdapter mazeAdapter(maze_);
-    std::vector<Cluster> clusters;
+    Clusters clusters;
     int clusterId = 0;
 
     for (int row = 0; row < maze_->height(); row++) {

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -52,12 +52,12 @@ DotClusterFinder::Clusters DotClusterFinder::findDotClusters() const {
 Positions DotClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const {
     Positions dots;
 
-    std::queue<Position> bfsQueue;
-    bfsQueue.push(start.position);
+    std::queue<Position> explorationQueue;
+    explorationQueue.push(start.position);
 
-    while (!bfsQueue.empty()) {
-        Position currentPosition = bfsQueue.front();
-        bfsQueue.pop();
+    while (!explorationQueue.empty()) {
+        Position currentPosition = explorationQueue.front();
+        explorationQueue.pop();
         ClusterCell& current = mazeAdapter.cell(currentPosition);
 
         if (current.visited) {
@@ -76,7 +76,7 @@ Positions DotClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapte
             ClusterCell& neighbor = mazeAdapter.cell(nextPosition);
 
             if (neighbor.isConsumable() && !neighbor.visited) {
-                bfsQueue.push(nextPosition);
+                explorationQueue.push(nextPosition);
             }
         }
     }

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -32,7 +32,7 @@ Position Cluster::findClusterCenter() const {
     return closestDot;
 }
 
-Positions ClusterFinder::clusterCenters() const {
+Positions ClusterFinder::dotClusterCenters() const {
     Positions centerDots;
     for (const auto& cluster : clusters_) {
         centerDots.push_back(cluster.center);

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -32,8 +32,8 @@ Position Cluster::findClusterCenter() const {
     return closestDot;
 }
 
-std::vector<Position> ClusterFinder::clusterCenters() const {
-    std::vector<Position> centerDots;
+Positions ClusterFinder::clusterCenters() const {
+    Positions centerDots;
     for (const auto& cluster : clusters_) {
         centerDots.push_back(cluster.center);
     }
@@ -53,15 +53,15 @@ ClusterFinder::Clusters ClusterFinder::findDotClusters() const {
             if (startCell.type != TileType::DOT || startCell.visited) {
                 continue;
             }
-            std::vector<Position> dots = expandDot(startCell, mazeAdapter);
+            Positions dots = expandDot(startCell, mazeAdapter);
             clusters.emplace_back(clusterId++, dots);
         }
     }
     return clusters;
 }
 
-std::vector<Position> ClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const {
-    std::vector<Position> dots;
+Positions ClusterFinder::expandDot(const Cell& start, const ClusterMazeAdapter& mazeAdapter) const {
+    Positions dots;
 
     std::queue<Position> bfsQueue;
     bfsQueue.push(start.position);

--- a/demo/src/cluster.cpp
+++ b/demo/src/cluster.cpp
@@ -6,6 +6,9 @@
 namespace utils {
 
 Position Cluster::findClusterCenter() const {
+    if (dots.empty()) {
+        throw std::runtime_error("Cannot find center of an empty cluster");
+    }
     int sumX = 0;
     int sumY = 0;
 
@@ -14,20 +17,14 @@ Position Cluster::findClusterCenter() const {
         sumY += point.y;
     }
 
-    int avgX = std::floor(sumX / dots.size());
-    int avgY = std::floor(sumY / dots.size());
+    const int avgX = std::floor(sumX / dots.size());
+    const int avgY = std::floor(sumY / dots.size());
 
-    Position avgPosition{avgX, avgY};
-    Position closestDot = dots.front();
-    double minDistance = std::numeric_limits<double>::max();
-
-    for (const auto& dot : dots) {
-        double distance = avgPosition.distance(dot);
-        if (distance < minDistance) {
-            minDistance = distance;
-            closestDot = dot;
-        }
-    }
+    const Position avgPosition{avgX, avgY};
+    auto distanceComparator = [&avgPosition](const Position& lhs, const Position& rhs) {
+        return avgPosition.distance(lhs) < avgPosition.distance(rhs);
+    };
+    Position closestDot = *std::min_element(dots.begin(), dots.end(), distanceComparator);
 
     return closestDot;
 }

--- a/demo/test/astar.cpp
+++ b/demo/test/astar.cpp
@@ -6,7 +6,7 @@
 
 #include "mock_environment_model.hpp"
 
-namespace utils {
+namespace utils::a_star {
 
 using namespace demo;
 
@@ -145,4 +145,4 @@ TEST_F(AStarTest, pathToClosestDot) {
     ASSERT_EQ(path->size(), 3);
 }
 
-} // namespace utils
+} // namespace utils::a_star

--- a/demo/test/astar.cpp
+++ b/demo/test/astar.cpp
@@ -95,11 +95,12 @@ TEST_F(AStarTest, path) {
     environmentModel_->setMaze({5, 5}, str);
 
     AStar astar(environmentModel_->maze());
-    Path path = astar.shortestPath({2, 1}, {3, 3});
+    std::optional<Path> path = astar.shortestPath({2, 1}, {3, 3});
     Path targetPath = {Direction::LEFT, Direction::DOWN, Direction::DOWN, Direction::RIGHT, Direction::RIGHT};
-    ASSERT_EQ(path.size(), targetPath.size());
+    ASSERT_TRUE(path.has_value());
+    ASSERT_EQ(path->size(), targetPath.size());
     for (int i = 0; i < targetPath.size(); i++) {
-        EXPECT_EQ(path.at(i), targetPath.at(i));
+        EXPECT_EQ(path->at(i), targetPath.at(i));
     }
 }
 
@@ -112,13 +113,15 @@ TEST_F(AStarTest, pathWithTunnel) {
     environmentModel_->setMaze({5, 5}, str);
 
     AStar astar(environmentModel_->maze());
-    Path path = astar.shortestPath({0, 2}, {4, 2});
-    ASSERT_EQ(path.size(), 1);
-    EXPECT_EQ(path.front(), demo::Direction::LEFT);
+    std::optional<Path> path = astar.shortestPath({0, 2}, {4, 2});
+    ASSERT_TRUE(path.has_value());
+    ASSERT_EQ(path->size(), 1);
+    EXPECT_EQ(path->front(), demo::Direction::LEFT);
 
     path = astar.shortestPath({4, 2}, {0, 2});
-    ASSERT_EQ(path.size(), 1);
-    EXPECT_EQ(path.front(), demo::Direction::RIGHT);
+    ASSERT_TRUE(path.has_value());
+    ASSERT_EQ(path->size(), 1);
+    EXPECT_EQ(path->front(), demo::Direction::RIGHT);
 }
 
 TEST_F(AStarTest, pathToClosestDot) {

--- a/demo/test/change_dot_cluster_behavior.cpp
+++ b/demo/test/change_dot_cluster_behavior.cpp
@@ -1,0 +1,132 @@
+#include "demo/change_dot_cluster_behavior.hpp"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "mock_environment_model.hpp"
+
+namespace demo {
+
+class ChangeDotClusterBehaviorTest : public ::testing::Test {
+protected:
+    ChangeDotClusterBehaviorTest()
+            : environmentModel_(std::make_shared<MockEnvironmentModel>()),
+              changeDotClusterBehavior_{environmentModel_} {
+        setMazeWithTwoClusters();
+        environmentModel_->setGhostPositions({1, 1});
+    }
+
+    void setMazeWithoutClusters() {
+        const char str[] = {"#####"
+                            "#   #"
+                            "#   #"
+                            "#   #"
+                            "#   #"
+                            "#####"};
+        environmentModel_->setMaze({5, 6}, str);
+    }
+    void setMazeWithOneCluster() {
+        const char str[] = {"#####"
+                            "#o..#"
+                            "#   #"
+                            "#   #"
+                            "#   #"
+                            "#####"};
+        environmentModel_->setMaze({5, 6}, str);
+    }
+    void setMazeWithTwoClusters() {
+        const char str[] = {"#####"
+                            "#o..#"
+                            "#   #"
+                            "#   #"
+                            "#.. #"
+                            "#####"};
+        environmentModel_->setMaze({5, 6}, str);
+    }
+
+    MockEnvironmentModel::Ptr environmentModel_;
+
+    ChangeDotClusterBehavior changeDotClusterBehavior_;
+};
+
+TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionTrue) {
+    Time time = Clock::now();
+
+    // The invocation condition should be true if...
+
+    // ...we are outside the only cluster that's left
+    setMazeWithOneCluster();
+    environmentModel_->setPacmanPosition({1, 3});
+
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+
+    // ...or there are multiple clusters left. Doesn't matter if we are outside...
+    setMazeWithTwoClusters();
+    environmentModel_->setPacmanPosition({1, 3});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+
+    // .. or inside a cluster in that case
+    environmentModel_->setPacmanPosition({1, 1});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+}
+
+TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionFalse) {
+    Time time = Clock::now();
+
+    // The invocation condition should be false if...
+
+    // ..there are no clusters left
+    setMazeWithoutClusters();
+    environmentModel_->setPacmanPosition({1, 3});
+
+    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time));
+
+    // ...we are inside the only cluster that's left
+    setMazeWithOneCluster();
+    environmentModel_->setPacmanPosition({1, 1});
+
+    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time));
+}
+
+TEST_F(ChangeDotClusterBehaviorTest, checkCommitmentConditionTrue) {
+    Time time = Clock::now();
+    setMazeWithTwoClusters();
+    environmentModel_->setPacmanPosition({1, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+
+    // Once we gained control, we commit to reaching the target dot cluster
+    changeDotClusterBehavior_.gainControl(time);
+    ASSERT_TRUE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+}
+
+TEST_F(ChangeDotClusterBehaviorTest, checkCommitmentConditionFalse) {
+    Time time = Clock::now();
+    setMazeWithTwoClusters();
+    environmentModel_->setPacmanPosition({1, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    changeDotClusterBehavior_.gainControl(time);
+
+    // Once we reached the target cluster, we finished our intended behavior and give up the commitment
+    environmentModel_->setPacmanPosition({2, 1});
+    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+
+    // We reached our goal no matter if we reached the cluster center or just any of the cluster dots
+    environmentModel_->setPacmanPosition({1, 1});
+    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+}
+
+TEST_F(ChangeDotClusterBehaviorTest, getCommand) {
+    Time time = Clock::now();
+    setMazeWithTwoClusters();
+    environmentModel_->setPacmanPosition({2, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+
+    changeDotClusterBehavior_.gainControl(time);
+
+    // The resulting command should navigate us towards the closest cluster center
+    Command command = changeDotClusterBehavior_.getCommand(time);
+    ASSERT_EQ(command.nextDirection(), Direction::UP);
+}
+
+} // namespace demo

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -18,7 +18,7 @@ protected:
 
 TEST_F(ClusterTest, dotClusters) {
     const char str[] = {"#####"
-                        "#...#"
+                        "#o..#"
                         "     "
                         "#.. #"
                         "#####"};

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -26,12 +26,12 @@ TEST_F(ClusterTest, dotClusters) {
 
     ClusterFinder clusterFinder(environmentModel_->maze());
 
-    std::vector<Cluster> clusters = clusterFinder.clusters();
+    std::vector<Cluster> clusters = clusterFinder.dotClusters();
     ASSERT_EQ(clusters.size(), 2);
     EXPECT_EQ(clusters.front().dots.size(), 3);
     EXPECT_EQ(clusters.back().dots.size(), 2);
 
-    Positions clusterCenter = clusterFinder.clusterCenters();
+    Positions clusterCenter = clusterFinder.dotClusterCenters();
     ASSERT_EQ(clusterCenter.size(), 2);
     EXPECT_EQ(clusterCenter.front().x, 2);
     EXPECT_EQ(clusterCenter.front().y, 1);

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -8,6 +8,20 @@ namespace utils::a_star {
 
 using namespace demo;
 
+struct ExpectedCluster {
+    int expectedSize;
+    Position center;
+
+    bool matches(const Cluster& cluster) const {
+        return cluster.dots.size() == expectedSize && cluster.center == center;
+    }
+};
+
+bool clusterExists(const std::vector<Cluster>& clusters, const ExpectedCluster& expectedCluster) {
+    return std::any_of(
+        clusters.begin(), clusters.end(), [&](const Cluster& cluster) { return expectedCluster.matches(cluster); });
+}
+
 class ClusterTest : public ::testing::Test {
 protected:
     ClusterTest() : environmentModel_(std::make_shared<MockEnvironmentModel>()) {
@@ -25,17 +39,14 @@ TEST_F(ClusterTest, dotClusters) {
     environmentModel_->setMaze({5, 5}, str);
 
     DotClusterFinder dotClusterFinder(environmentModel_->maze());
-
     std::vector<Cluster> clusters = dotClusterFinder.clusters();
-
     ASSERT_EQ(clusters.size(), 2);
-    EXPECT_EQ(clusters.front().dots.size(), 3);
-    EXPECT_EQ(clusters.front().center.x, 2);
-    EXPECT_EQ(clusters.front().center.y, 1);
 
-    EXPECT_EQ(clusters.back().dots.size(), 2);
-    EXPECT_EQ(clusters.back().center.x, 1);
-    EXPECT_EQ(clusters.back().center.y, 3);
+    ExpectedCluster firstExpectedCluster{3, {2, 1}};
+    ExpectedCluster secondExpectedCluster{2, {1, 3}};
+
+    EXPECT_TRUE(clusterExists(clusters, firstExpectedCluster));
+    EXPECT_TRUE(clusterExists(clusters, secondExpectedCluster));
 }
 
 } // namespace utils::a_star

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -24,9 +24,9 @@ TEST_F(ClusterTest, dotClusters) {
                         "#####"};
     environmentModel_->setMaze({5, 5}, str);
 
-    ClusterFinder clusterFinder(environmentModel_->maze());
+    DotClusterFinder dotClusterFinder(environmentModel_->maze());
 
-    std::vector<Cluster> clusters = clusterFinder.dotClusters();
+    std::vector<Cluster> clusters = dotClusterFinder.clusters();
 
     ASSERT_EQ(clusters.size(), 2);
     EXPECT_EQ(clusters.front().dots.size(), 3);

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -31,7 +31,7 @@ TEST_F(ClusterTest, dotClusters) {
     EXPECT_EQ(clusters.front().dots.size(), 3);
     EXPECT_EQ(clusters.back().dots.size(), 2);
 
-    std::vector<Position> clusterCenter = clusterFinder.clusterCenters();
+    Positions clusterCenter = clusterFinder.clusterCenters();
     ASSERT_EQ(clusterCenter.size(), 2);
     EXPECT_EQ(clusterCenter.front().x, 2);
     EXPECT_EQ(clusterCenter.front().y, 1);

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -16,7 +16,7 @@ protected:
     MockEnvironmentModel::Ptr environmentModel_;
 };
 
-TEST_F(ClusterTest, findDotClusters) {
+TEST_F(ClusterTest, dotClusters) {
     const char str[] = {"#####"
                         "#...#"
                         "     "
@@ -25,18 +25,21 @@ TEST_F(ClusterTest, findDotClusters) {
     environmentModel_->setMaze({5, 5}, str);
 
     ClusterFinder clusterFinder(environmentModel_->maze());
-    std::vector<Cluster> clusters = clusterFinder.findDotClusters();
 
-    EXPECT_EQ(clusters.size(), 2);
+    std::vector<Cluster> clusters = clusterFinder.clusters();
+    ASSERT_EQ(clusters.size(), 2);
     EXPECT_EQ(clusters.front().dots.size(), 3);
-    EXPECT_EQ(clusters.front().center.x, 2);
-    EXPECT_EQ(clusters.front().center.y, 1);
-
     EXPECT_EQ(clusters.back().dots.size(), 2);
+
+    std::vector<Position> clusterCenter = clusterFinder.clusterCenters();
+    ASSERT_EQ(clusterCenter.size(), 2);
+    EXPECT_EQ(clusterCenter.front().x, 2);
+    EXPECT_EQ(clusterCenter.front().y, 1);
+
     // We are using std::floor when computing the cluster center so in this
     // case the center should be the left of two dots
-    EXPECT_EQ(clusters.back().center.x, 1);
-    EXPECT_EQ(clusters.back().center.y, 3);
+    EXPECT_EQ(clusterCenter.back().x, 1);
+    EXPECT_EQ(clusterCenter.back().y, 3);
 }
 
 } // namespace utils::a_star

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -25,11 +25,18 @@ TEST_F(ClusterTest, findDotClusters) {
     environmentModel_->setMaze({5, 5}, str);
 
     ClusterFinder clusterFinder(environmentModel_->maze());
-    std::vector<Cluster> cluster = clusterFinder.findDotClusters();
+    std::vector<Cluster> clusters = clusterFinder.findDotClusters();
 
-    EXPECT_EQ(cluster.size(), 2);
-    EXPECT_EQ(cluster.front().dots.size(), 3);
-    EXPECT_EQ(cluster.back().dots.size(), 2);
+    EXPECT_EQ(clusters.size(), 2);
+    EXPECT_EQ(clusters.front().dots.size(), 3);
+    EXPECT_EQ(clusters.front().center.x, 2);
+    EXPECT_EQ(clusters.front().center.y, 1);
+
+    EXPECT_EQ(clusters.back().dots.size(), 2);
+    // We are using std::floor when computing the cluster center so in this
+    // case the center should be the left of two dots
+    EXPECT_EQ(clusters.back().center.x, 1);
+    EXPECT_EQ(clusters.back().center.y, 3);
 }
 
 } // namespace utils::a_star

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -1,0 +1,35 @@
+#include "utils/cluster.hpp"
+
+#include <gtest/gtest.h>
+
+#include "mock_environment_model.hpp"
+
+namespace utils::a_star {
+
+using namespace demo;
+
+class ClusterTest : public ::testing::Test {
+protected:
+    ClusterTest() : environmentModel_(std::make_shared<MockEnvironmentModel>()) {
+    }
+
+    MockEnvironmentModel::Ptr environmentModel_;
+};
+
+TEST_F(ClusterTest, findDotClusters) {
+    const char str[] = {"#####"
+                        "#...#"
+                        "     "
+                        "#.. #"
+                        "#####"};
+    environmentModel_->setMaze({5, 5}, str);
+
+    ClusterFinder clusterFinder(environmentModel_->maze());
+    std::vector<Cluster> cluster = clusterFinder.findDotClusters();
+
+    EXPECT_EQ(cluster.size(), 2);
+    EXPECT_EQ(cluster.front().dots.size(), 3);
+    EXPECT_EQ(cluster.back().dots.size(), 2);
+}
+
+} // namespace utils::a_star

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -27,19 +27,15 @@ TEST_F(ClusterTest, dotClusters) {
     ClusterFinder clusterFinder(environmentModel_->maze());
 
     std::vector<Cluster> clusters = clusterFinder.dotClusters();
+
     ASSERT_EQ(clusters.size(), 2);
     EXPECT_EQ(clusters.front().dots.size(), 3);
+    EXPECT_EQ(clusters.front().center.x, 2);
+    EXPECT_EQ(clusters.front().center.y, 1);
+
     EXPECT_EQ(clusters.back().dots.size(), 2);
-
-    Positions clusterCenter = clusterFinder.dotClusterCenters();
-    ASSERT_EQ(clusterCenter.size(), 2);
-    EXPECT_EQ(clusterCenter.front().x, 2);
-    EXPECT_EQ(clusterCenter.front().y, 1);
-
-    // We are using std::floor when computing the cluster center so in this
-    // case the center should be the left of two dots
-    EXPECT_EQ(clusterCenter.back().x, 1);
-    EXPECT_EQ(clusterCenter.back().y, 3);
+    EXPECT_EQ(clusters.back().center.x, 1);
+    EXPECT_EQ(clusters.back().center.y, 3);
 }
 
 } // namespace utils::a_star

--- a/demo/test/mock_environment_model.hpp
+++ b/demo/test/mock_environment_model.hpp
@@ -67,7 +67,7 @@ public:
     void setMaze(const Position& size, const char (&str)[Size]) {
         maze_ = std::make_shared<Maze>(makeCustomMazeState({size.x, size.y}, str));
         astar_ = utils::AStar(maze_);
-        clusterFinder_ = utils::ClusterFinder(maze_);
+        clusterFinder_ = utils::DotClusterFinder(maze_);
     }
     void setEmptyMaze() {
         const char str[] = {"##########"

--- a/demo/test/mock_environment_model.hpp
+++ b/demo/test/mock_environment_model.hpp
@@ -67,6 +67,7 @@ public:
     void setMaze(const Position& size, const char (&str)[Size]) {
         maze_ = std::make_shared<Maze>(makeCustomMazeState({size.x, size.y}, str));
         astar_ = utils::AStar(maze_);
+        clusterFinder_ = utils::ClusterFinder(maze_);
     }
     void setEmptyMaze() {
         const char str[] = {"##########"


### PR DESCRIPTION
Closes #26 

This should be the final behavior :partying_face: 

I did go for a cluster segmentation algorithm (just a simple breadth first search) as opposed to the quadrant thing we discussed since it seemed more sensible when I started implementing it.

So we now split the dots into clusters (sets of connected dots) using the clustering algorithm in `cluster.hpp`. I did move the `MazeAdapter` and `Cell` class into `maze.hpp` and generalized it such that both the clustering algorithm and the A* could utilize these classes. For each cluster, we also compute the center by averaging the x and y coordinates and finding the dot closest to that position.

Given the clusters and their respective centers. the new behavior now plans a path from the current position to the center of the closest cluster except for the one that pacman might already be in and commits to it until one of the cluster dots has been reached.

There is one relatively unrelated commit in here:
c27930ef6eb906ae2bf66d497b066bc12247be18 Fixes a bug that caused a crash when pacman entered the tunnel while chasing or avoiding a ghost. It was a lot easier to fix on this branch because the `positionConsideringTunnel` function has been moved out of the A* class.