### PR TITLE
Render path

### DIFF
--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -100,6 +100,8 @@ public:
         return astar_.pathToClosestDot(position);
     }
 
+    Positions toAbsolutePath(const Path& path) const;
+
     bool isDot(const Position& position) const {
         return maze_->isDot(position);
     }

--- a/demo/include/demo/pacman_agent.hpp
+++ b/demo/include/demo/pacman_agent.hpp
@@ -71,6 +71,10 @@ public:
         environmentModel_->update(game);
     }
 
+    EnvironmentModel::ConstPtr environmentModel() const {
+        return environmentModel_;
+    }
+
     std::ostream& to_stream(std::ostream& output, const Time& time) const {
         return rootArbitrator_->to_stream(output, time);
     }

--- a/demo/include/utils/pacman_wrapper.hpp
+++ b/demo/include/utils/pacman_wrapper.hpp
@@ -6,6 +6,7 @@
 #include <pacman/util/sdl_delete.hpp>
 #include <pacman/util/sdl_quad_writer.hpp>
 
+#include "demo/environment_model.hpp"
 #include "demo/types.hpp"
 
 namespace utils {
@@ -17,7 +18,7 @@ public:
         SDL_Quit();
     }
 
-    void progressGame(const demo::Command& command);
+    void progressGame(const demo::Command& command, const demo::EnvironmentModel::ConstPtr& environmentModel);
 
     bool quit() const {
         return quit_;

--- a/demo/include/utils/pacman_wrapper.hpp
+++ b/demo/include/utils/pacman_wrapper.hpp
@@ -39,8 +39,10 @@ private:
 
     Game game_;
     int frame_{0};
-    bool quit_{false};
+
     bool pause_{false};
+    bool quit_{false};
+    bool renderPath_{false};
 };
 
 } // namespace utils

--- a/demo/include/utils/pacman_wrapper.hpp
+++ b/demo/include/utils/pacman_wrapper.hpp
@@ -29,6 +29,7 @@ public:
 
 private:
     void handleUserInput();
+    void renderPath(const demo::Positions& path);
 
     int scaleFactor_;
     SDL::Window window_;

--- a/demo/include/utils/utils.hpp
+++ b/demo/include/utils/utils.hpp
@@ -5,8 +5,6 @@
 
 namespace utils {
 
-Positions toAbsolutePath(const demo::Path& path, const demo::EnvironmentModel::ConstPtr& environmentModel);
-
 int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel::ConstPtr& environmentModel);
 
 int dotsInRadius(const Position& center,

--- a/demo/src/cost_estimator.cpp
+++ b/demo/src/cost_estimator.cpp
@@ -5,7 +5,7 @@
 namespace demo {
 
 double CostEstimator::estimateCost(const Command& command, bool /*isActive*/) {
-    Positions absolutePath = utils::toAbsolutePath(command.path, environmentModel_);
+    Positions absolutePath = environmentModel_->toAbsolutePath(command.path);
 
     const int nDotsAlongPath = utils::dotsAlongPath(absolutePath, environmentModel_);
     const int nDotsInRadius =

--- a/demo/src/environment_model.cpp
+++ b/demo/src/environment_model.cpp
@@ -62,4 +62,19 @@ EnvironmentModel::GhostWithDistance EnvironmentModel::closestGhost(const Ghosts&
     return {closestGhost, minGhostDistance};
 }
 
+Positions EnvironmentModel::toAbsolutePath(const Path& path) const {
+
+    Position currentPosition = pacmanPosition();
+    Positions absolutePath;
+
+    // Let's follow the path and convert it to absolute positions
+    for (const auto& direction : path) {
+        currentPosition = currentPosition + Move(direction).deltaPosition;
+        currentPosition = positionConsideringTunnel(currentPosition);
+        absolutePath.push_back(currentPosition);
+    }
+
+    return absolutePath;
+}
+
 } // namespace demo

--- a/demo/src/main.cpp
+++ b/demo/src/main.cpp
@@ -19,7 +19,7 @@ int main() {
             Command command = agent.getCommand(Clock::now());
             std::cout << agent.to_str(Clock::now()) << '\n';
 
-            demo.progressGame(command);
+            demo.progressGame(command, agent.environmentModel());
         }
     } catch (std::exception& e) {
         std::cout << e.what() << '\n';

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -49,6 +49,7 @@ PacmanWrapper::PacmanWrapper()
           renderer_(createRendererAndSetLogicalSize(window_)),
           maze_(SDL::loadTexture(renderer_.get(), animera::getTextureInfo())), writer_({renderer_.get(), maze_.get()}) {
     game_.init();
+    SDL_SetRenderDrawBlendMode(renderer_.get(), SDL_BLENDMODE_BLEND);
 }
 
 void PacmanWrapper::handleUserInput() {
@@ -92,10 +93,28 @@ void PacmanWrapper::progressGame(const demo::Command& command,
     SDL_CHECK(SDL_SetRenderDrawColor(renderer_.get(), 0, 0, 0, 255));
     SDL_CHECK(SDL_RenderClear(renderer_.get()));
     game_.render(writer_, frame_ % tileSize);
+    renderPath(environmentModel->toAbsolutePath(command.path));
+
     frame_++;
     SDL_RenderPresent(renderer_.get());
 
     FrameCap sync{fps};
+}
+
+void PacmanWrapper::renderPath(const demo::Positions& path) {
+    // Set path color and transparency
+    SDL_CHECK(SDL_SetRenderDrawColor(renderer_.get(), 0, 255, 0, 90));
+
+    SDL_Rect rect;
+    rect.w = tileSize;
+    rect.h = tileSize;
+
+    for (const auto& position : path) {
+        rect.x = position.x * tileSize;
+        rect.y = position.y * tileSize;
+
+        SDL_RenderFillRect(renderer_.get(), &rect);
+    }
 }
 
 } // namespace utils

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -69,6 +69,10 @@ void PacmanWrapper::handleUserInput() {
                 quit_ = true;
                 break;
             }
+            if (event.key.keysym.scancode == SDL_SCANCODE_P) {
+                renderPath_ = !renderPath_;
+                break;
+            }
         }
     }
 }
@@ -93,7 +97,10 @@ void PacmanWrapper::progressGame(const demo::Command& command,
     SDL_CHECK(SDL_SetRenderDrawColor(renderer_.get(), 0, 0, 0, 255));
     SDL_CHECK(SDL_RenderClear(renderer_.get()));
     game_.render(writer_, frame_ % tileSize);
-    renderPath(environmentModel->toAbsolutePath(command.path));
+
+    if (renderPath_) {
+        renderPath(environmentModel->toAbsolutePath(command.path));
+    }
 
     frame_++;
     SDL_RenderPresent(renderer_.get());

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -72,7 +72,8 @@ void PacmanWrapper::handleUserInput() {
     }
 }
 
-void PacmanWrapper::progressGame(const demo::Command& command) {
+void PacmanWrapper::progressGame(const demo::Command& command,
+                                 const demo::EnvironmentModel::ConstPtr& environmentModel) {
     handleUserInput();
 
     game_.input(command.scancode());

--- a/demo/src/utils.cpp
+++ b/demo/src/utils.cpp
@@ -2,22 +2,6 @@
 
 namespace utils {
 
-Positions toAbsolutePath(const demo::Path& path, const demo::EnvironmentModel::ConstPtr& environmentModel) {
-    using namespace demo;
-
-    Position pacmanPosition = environmentModel->pacmanPosition();
-    Positions absolutePath;
-
-    // Let's follow the path and convert it to absolute positions
-    for (const auto& direction : path) {
-        pacmanPosition = pacmanPosition + Move(direction).deltaPosition;
-        pacmanPosition = environmentModel->positionConsideringTunnel(pacmanPosition);
-        absolutePath.push_back(pacmanPosition);
-    }
-
-    return absolutePath;
-}
-
 int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel::ConstPtr& environmentModel) {
     int nDots{0};
 


### PR DESCRIPTION
Here's a basic implementation of how we could render the planned path. This is what it looks like:

![pacman-rendered-path](https://github.com/user-attachments/assets/6f4795da-9ecd-493a-af34-9013396358c8)

A couple of things I would like to discuss before finalizing this PR:
- First of all: Do we even want something like that?
- If so, should we  change the `Command` up somehow to give us the "absolute path"? The implementation right now kind of duplicates the `toAbsolutePath` function to keep the interfaces clean.
- Is it worth the time and effort to not render the full tile, i.e. just the center line of the path? It certainly would look nicer but makes things more complicated because you have to check if the path is horizontal/vertical (relatively easy) and whether it has corners.

@orzechow Let's discuss this one later.