### PR TITLE
Read version from file and tag docker image in GitHub workflow

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -3,13 +3,16 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main
+      - add_version_tag_to_docker_image # TODO: switch to main before merge
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -25,9 +28,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read version from file
+        run: |
+          cat version >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ghcr.io/kit-mrt/arbitration_graphs:latest
-
+          tags: |
+            ghcr.io/kit-mrt/arbitration_graphs:latest
+            ghcr.io/kit-mrt/arbitration_graphs:${{ env.VERSION }}

--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - add_version_tag_to_docker_image # TODO: switch to main before merge
+      - main
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
I just wanted to try the demo since it finally made it into master :rocket: 

I realized, that we never created the version tag for the docker images. I'm not sure if that was planned in #61 but I figured we should fix this one quickly because the current master won't work (without adjustments at least).

So this PR just adds to the workflow by reading the version from the version file and tagging the docker image we are building already. [I tested the action on this branch already])https://github.com/KIT-MRT/arbitration_graphs/actions/runs/11611034651) so we should be good to go.