### PR TITLE
Make "latest" the default version of demo docker build

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION
+ARG VERSION=latest
 FROM ghcr.io/kit-mrt/arbitration_graphs:$VERSION AS tutorial
 
 USER root


### PR DESCRIPTION
Just a tiny enhancement: This fixes a warning message about a potentially invalid base image:
`WARN: InvalidDefaultArgInFrom: Default value for ARG ghcr.io/kit-mrt/arbitration_graphs:$VERSION results in empty or invalid base image name (line 2)`