### PR TITLE
Ignore the gui folder in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ exclude:
   - cmake
   - CMakeLists.txt
   - demo
+  - gui
   - include
   - src
   - test


### PR DESCRIPTION
A tiny change, making sure the gui folder doesn't end up on our GitHub Pages site.