### PR TITLE
Add release and unit test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Arbitration Graphs
 
-[![License](https://img.shields.io/github/license/KIT-MRT/arbitration_graphs)](./LICENSE)
+![Latest Release](https://img.shields.io/github/v/release/KIT-MRT/arbitration_graphs?color=green) 
+![License](https://img.shields.io/github/license/KIT-MRT/arbitration_graphs)
+![Unit Test Status](https://img.shields.io/github/actions/workflow/status/KIT-MRT/arbitration_graphs/run-unit-tests.yaml?branch=main&label=tests)
 
 **Hierarchical behavior models for complex decision-making and behavior generation in robotics!**
 


### PR DESCRIPTION
This adds badges for the current release version and the test status. Test coverage would also be nice but that would require some additional tooling.

![image](https://github.com/user-attachments/assets/3fb5ddd2-93a3-45b8-b6dd-0eb3005cafac)
