### PR TITLE
Fix cost arbitrator called twice #patch

### DIFF
--- a/include/arbitration_graphs/arbitrator.hpp
+++ b/include/arbitration_graphs/arbitrator.hpp
@@ -63,7 +63,15 @@ public:
 
         typename Behavior<SubCommandT>::Ptr behavior_;
         FlagsT flags_;
+        mutable util_caching::Cache<Time, SubCommandT> command_;
         mutable util_caching::Cache<Time, VerificationResultT> verificationResult_;
+
+        SubCommandT getCommand(const Time& time) const {
+            if (!command_.cached(time)) {
+                command_.cache(time, behavior_->getCommand(time));
+            }
+            return command_.cached(time).value();
+        }
 
         bool hasFlag(const FlagsT& flag_to_check) const {
             return flags_ & flag_to_check;

--- a/include/arbitration_graphs/cost_arbitrator.hpp
+++ b/include/arbitration_graphs/cost_arbitrator.hpp
@@ -76,7 +76,7 @@ public:
 
 
     CostArbitrator(const std::string& name = "CostArbitrator", const VerifierT& verifier = VerifierT())
-            : ArbitratorBase(name, verifier){};
+            : ArbitratorBase(name, verifier) {};
 
 
     void addOption(const typename Behavior<SubCommandT>::Ptr& behavior,
@@ -118,10 +118,10 @@ private:
 
             double cost;
             if (isActive) {
-                cost = option->costEstimator_->estimateCost(option->behavior_->getCommand(time), isActive);
+                cost = option->costEstimator_->estimateCost(option->getCommand(time), isActive);
             } else {
                 option->behavior_->gainControl(time);
-                cost = option->costEstimator_->estimateCost(option->behavior_->getCommand(time), isActive);
+                cost = option->costEstimator_->estimateCost(option->getCommand(time), isActive);
                 option->behavior_->loseControl(time);
             }
             option->last_estimated_cost_ = cost;

--- a/include/arbitration_graphs/internal/arbitrator_impl.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_impl.hpp
@@ -51,7 +51,7 @@ template <typename CommandT, typename SubCommandT, typename VerifierT, typename 
 std::optional<SubCommandT> Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::getAndVerifyCommand(
     const typename Option::Ptr& option, const Time& time) const {
     try {
-        const SubCommandT command = option->behavior_->getCommand(time);
+        const SubCommandT command = option->getCommand(time);
 
         const VerificationResultT verificationResult = verifier_.analyze(time, command);
         option->verificationResult_.cache(time, verificationResult);

--- a/test/dummy_types.hpp
+++ b/test/dummy_types.hpp
@@ -41,10 +41,10 @@ public:
     using Ptr = std::shared_ptr<DummyBehavior>;
 
     DummyBehavior(const bool invocation, const bool commitment, const std::string& name = "DummyBehavior")
-            : Behavior(name), invocationCondition_{invocation}, commitmentCondition_{commitment}, loseControlCounter_{
-                                                                                                      0} {};
+            : Behavior(name), invocationCondition_{invocation}, commitmentCondition_{commitment} {};
 
     DummyCommand getCommand(const Time& time) override {
+        getCommandCounter_++;
         return name_;
     }
     bool checkInvocationCondition(const Time& time) const override {
@@ -59,7 +59,8 @@ public:
 
     bool invocationCondition_;
     bool commitmentCondition_;
-    int loseControlCounter_;
+    int getCommandCounter_{0};
+    int loseControlCounter_{0};
 };
 
 struct DummyResult {


### PR DESCRIPTION
Closes #62 

The `CostArbitrator` calls `getCommand` twice. Once in `getAndVerifyCommand` like all verifier types but also once in `sortOptionsByGivenPolicy` since the command is required to estimate the cost.
The call to `getCommand` can potentially be quite expensive, though. Therefore, this PR adds a cache for it inside the `Arbitrator::Option` class. When computing a command, the arbitrator now doesn't call the behavior directly anymore but instead calls the wrapper inside the `Option` class. Should the function be called two or more times inside a single time step, the cached command is returned and the behavior is not called again.