### PR TITLE
Fix Crow package name in deb dependency definition.

### DIFF
--- a/cmake/cpack_config.cmake
+++ b/cmake/cpack_config.cmake
@@ -32,7 +32,7 @@ set(CPACK_DEBIAN_GUI_PACKAGE_NAME "libarbitration-graphs-gui-dev")
 
 # Component-specific dependencies (make sure to use upper-case!)
 set(CPACK_DEBIAN_CORE_PACKAGE_DEPENDS "libgoogle-glog-dev, libyaml-cpp-dev, libutil-caching-dev")
-set(CPACK_DEBIAN_GUI_PACKAGE_DEPENDS "libarbitration-graphs-core-dev, Crow, zlib1g-dev")
+set(CPACK_DEBIAN_GUI_PACKAGE_DEPENDS "libarbitration-graphs-core-dev, crow, zlib1g-dev")
 
 # Use fixed debian file names
 set(CPACK_DEBIAN_CORE_FILE_NAME "${CPACK_DEBIAN_CORE_PACKAGE_NAME}.deb")


### PR DESCRIPTION
This fixes an issue in the dependency naming of the gui deb package.

The installed name of Crow is crow with a lower case. In the previous version, the dependency could not be resolved when installing the package via apt.

#patch