### PR TITLE
Bump the version using the #flags from the PR description

### DIFF
--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Compute new version
         id: bump_version
         run: |
-          initial_version=$(source version && echo ${VERSION#v})
-          new_version=$(.github/workflows/compute_version.sh "$initial_version" "${{ github.event.pull_request.body }}")
+          source version
+          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${{ github.event.pull_request.body }}")
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
   update-version-file:

--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      new_tag: ${{ steps.bump_version.outputs.new_tag }}
+      new_version: ${{ steps.bump_version.outputs.new_version }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -38,18 +38,18 @@ jobs:
 
       - name: Update version file with new version
         run: |
-          echo "New version: ${{ needs.compute-version.outputs.new_tag }}"
-          echo "VERSION=${{ needs.compute-version.outputs.new_tag }}" > version
+          echo "New version: ${{ needs.compute-version.outputs.new_version }}"
+          echo "VERSION=${{ needs.compute-version.outputs.new_version }}" > version
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add version
-          git commit -m "chore: update version file to ${{ needs.compute-version.outputs.new_tag }}"
+          git commit -m "chore: update version file to ${{ needs.compute-version.outputs.new_version }}"
           git push
 
       - name: Push new tag
         run: |
-          git tag ${{ needs.compute-version.outputs.new_tag }}
-          git push origin ${{ needs.compute-version.outputs.new_tag }}
+          git tag ${{ needs.compute-version.outputs.new_version }}
+          git push origin ${{ needs.compute-version.outputs.new_version }}
 
 
   create-release:
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.compute-version.outputs.new_tag }}
+          ref: ${{ needs.compute-version.outputs.new_version }}
 
       - name: Build release packages
         uses: docker/build-push-action@v6
@@ -82,7 +82,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "/tmp/artifacts/release/*"
-          tag: ${{ needs.compute-version.outputs.new_tag }}
+          tag: ${{ needs.compute-version.outputs.new_version }}
           body: ${{ github.event.pull_request.body }}
 
   build-and-run-release-tests:
@@ -93,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/arbitration_graphs/releases/download/${{ needs.compute-version.outputs.new_tag }}
+            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/arbitration_graphs/releases/download/${{ needs.compute-version.outputs.new_version }}
           push: false
           tags: release_tester_core
           target: release_test_core
@@ -106,7 +106,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/arbitration_graphs/releases/download/${{ needs.compute-version.outputs.new_tag }}
+            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/arbitration_graphs/releases/download/${{ needs.compute-version.outputs.new_version }}
           push: false
           tags: release_tester_gui
           target: release_test_gui
@@ -143,32 +143,32 @@ jobs:
           push: true
           tags: |
             ghcr.io/kit-mrt/arbitration_graphs:latest
-            ghcr.io/kit-mrt/arbitration_graphs:${{ needs.compute-version.outputs.new_tag }}
+            ghcr.io/kit-mrt/arbitration_graphs:${{ needs.compute-version.outputs.new_version }}
           target: install
 
       - name: Build and push Pacman demo Docker image
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            VERSION=${{ needs.compute-version.outputs.new_tag }}
+            VERSION=${{ needs.compute-version.outputs.new_version }}
           context: demo
           file: demo/Dockerfile
           push: true
           tags: |
             ghcr.io/kit-mrt/arbitration_graphs_pacman_demo:latest
-            ghcr.io/kit-mrt/arbitration_graphs_pacman_demo:${{ needs.compute-version.outputs.new_tag }}
+            ghcr.io/kit-mrt/arbitration_graphs_pacman_demo:${{ needs.compute-version.outputs.new_version }}
           target: demo
 
       - name: Build and push Pacman tutorial Docker image
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            VERSION=${{ needs.compute-version.outputs.new_tag }}
+            VERSION=${{ needs.compute-version.outputs.new_version }}
           context: demo
           file: demo/Dockerfile
           push: true
           tags: |
             ghcr.io/kit-mrt/arbitration_graphs_pacman_tutorial:latest
-            ghcr.io/kit-mrt/arbitration_graphs_pacman_tutorial:${{ needs.compute-version.outputs.new_tag }}
+            ghcr.io/kit-mrt/arbitration_graphs_pacman_tutorial:${{ needs.compute-version.outputs.new_version }}
           target: tutorial
 

--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -20,9 +20,11 @@ jobs:
 
       - name: Compute new version
         id: bump_version
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           source version
-          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${{ github.event.pull_request.body }}")
+          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${PR_BODY//[^a-zA-Z0-9#]/}")
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
   update-version-file:

--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -21,10 +21,9 @@ jobs:
       - name: Compute new version
         id: bump_version
         run: |
-          # Run the compute_version script and pass the PR description as an argument
-          cd .github/workflows
-          new_tag=$(./compute_version.sh "${{ github.event.pull_request.body }}")
-          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+          initial_version=$(source version && echo ${VERSION#v})
+          new_version=$(.github/workflows/compute_version.sh "$initial_version" "${{ github.event.pull_request.body }}")
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
   update-version-file:
     needs: compute-version

--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -18,23 +18,13 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Read version from file
-        run: |
-          # Read the version from the version file, only store the number (without the 'v')
-          INITIAL_VERSION=$(source version && echo ${VERSION#v})
-          echo "Current version: $INITIAL_VERSION"
-          echo "INITIAL_VERSION=${INITIAL_VERSION}" >> $GITHUB_ENV
-
-      - name: Bump version
+      - name: Compute new version
         id: bump_version
-        uses: anothrNick/github-tag-action@v1
-        env:
-          DEFAULT_BUMP: minor
-          DRY_RUN: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INITIAL_VERSION: ${{ env.INITIAL_VERSION }}
-          WITH_V: true
-
+        run: |
+          # Run the compute_version script and pass the PR description as an argument
+          cd .github/workflows
+          new_tag=$(./compute_version.sh "${{ github.event.pull_request.body }}")
+          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
 
   update-version-file:
     needs: compute-version

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -7,8 +7,8 @@ if [[ $# -ne 2 ]]; then
   exit 1
 fi
 
-initial_version="$1"
-input_string="$2"
+initial_version=${1//[^0-9.v]/}
+input_string=${2//[^a-zA-Z0-9#]/}
 
 # Extract the current version components
 major=$(echo "$initial_version" | cut -d'.' -f1 | cut -d'v' -f2)

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -2,23 +2,18 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VERSION_FILE="$SCRIPT_DIR/../../version"
-
-# Read the current version from the version file or default to v0.0.0
-if [[ -f "$VERSION_FILE" ]]; then
-  source "$VERSION_FILE"
-else
-  VERSION="v0.0.0"
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <input_string>"
+  exit 1
 fi
 
-# Extract the current version components
-major=$(echo $VERSION | cut -d'.' -f1 | cut -d'v' -f2)
-minor=$(echo $VERSION | cut -d'.' -f2)
-patch=$(echo $VERSION | cut -d'.' -f3)
+initial_version="$1"
+input_string="$2"
 
-# Read the PR description passed as an argument
-input_string="$1"
+# Extract the current version components
+major=$(echo "$initial_version" | cut -d'.' -f1 | cut -d'v' -f2)
+minor=$(echo "$initial_version" | cut -d'.' -f2)
+patch=$(echo "$initial_version" | cut -d'.' -f3)
 
 # Determine the bump type based on PR description
 if [[ "$input_string" == *"#major"* ]]; then

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -7,10 +7,10 @@ if [[ $# -ne 2 ]]; then
   exit 1
 fi
 
-initial_version=${1//[^0-9.v]/}
+initial_version=${1//[^0-9.]/}
 input_string=${2//[^a-zA-Z0-9#]/}
 
-initial_major=$(echo "$initial_version" | cut -d'.' -f1 | cut -d'v' -f2)
+initial_major=$(echo "$initial_version" | cut -d'.' -f1)
 initial_minor=$(echo "$initial_version" | cut -d'.' -f2)
 initial_patch=$(echo "$initial_version" | cut -d'.' -f3)
 

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION_FILE="$SCRIPT_DIR/../../version"
+
+# Read the current version from the version file or default to v0.0.0
+if [[ -f "$VERSION_FILE" ]]; then
+  source "$VERSION_FILE"
+else
+  VERSION="v0.0.0"
+fi
+
+# Extract the current version components
+major=$(echo $VERSION | cut -d'.' -f1 | cut -d'v' -f2)
+minor=$(echo $VERSION | cut -d'.' -f2)
+patch=$(echo $VERSION | cut -d'.' -f3)
+
+# Read the PR description passed as an argument
+input_string="$1"
+
+# Determine the bump type based on PR description
+if [[ "$input_string" == *"#major"* ]]; then
+  new_major=$((major + 1))
+  new_minor=0
+  new_patch=0
+elif [[ "$input_string" == *"#minor"* ]]; then
+  new_major=$major
+  new_minor=$((minor + 1))
+  new_patch=0
+elif [[ "$input_string" == *"#patch"* ]]; then
+  new_major=$major
+  new_minor=$minor
+  new_patch=$((patch + 1))
+else
+  # Default to minor bump
+  new_major=$major
+  new_minor=$((minor + 1))
+  new_patch=0
+fi
+
+# Construct the new version
+new_version="v${new_major}.${new_minor}.${new_patch}"
+
+# Output the new version
+echo "${new_version}"
+

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -10,34 +10,30 @@ fi
 initial_version=${1//[^0-9.v]/}
 input_string=${2//[^a-zA-Z0-9#]/}
 
-# Extract the current version components
-major=$(echo "$initial_version" | cut -d'.' -f1 | cut -d'v' -f2)
-minor=$(echo "$initial_version" | cut -d'.' -f2)
-patch=$(echo "$initial_version" | cut -d'.' -f3)
+initial_major=$(echo "$initial_version" | cut -d'.' -f1 | cut -d'v' -f2)
+initial_minor=$(echo "$initial_version" | cut -d'.' -f2)
+initial_patch=$(echo "$initial_version" | cut -d'.' -f3)
 
 # Determine the bump type based on PR description
 if [[ "$input_string" == *"#major"* ]]; then
-  new_major=$((major + 1))
+  new_major=$((initial_major + 1))
   new_minor=0
   new_patch=0
 elif [[ "$input_string" == *"#minor"* ]]; then
-  new_major=$major
-  new_minor=$((minor + 1))
+  new_major=$initial_major
+  new_minor=$((initial_minor + 1))
   new_patch=0
 elif [[ "$input_string" == *"#patch"* ]]; then
-  new_major=$major
-  new_minor=$minor
-  new_patch=$((patch + 1))
+  new_major=$initial_major
+  new_minor=$initial_minor
+  new_patch=$((initial_patch + 1))
 else
   # Default to minor bump
-  new_major=$major
-  new_minor=$((minor + 1))
+  new_major=$initial_major
+  new_minor=$((initial_minor + 1))
   new_patch=0
 fi
 
-# Construct the new version
 new_version="v${new_major}.${new_minor}.${new_patch}"
-
-# Output the new version
 echo "${new_version}"
 

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -14,7 +14,7 @@ initial_major=$(echo "$initial_version" | cut -d'.' -f1)
 initial_minor=$(echo "$initial_version" | cut -d'.' -f2)
 initial_patch=$(echo "$initial_version" | cut -d'.' -f3)
 
-# Determine the bump type based on PR description
+# Determine the bump type based on input string
 if [[ "$input_string" == *"#major"* ]]; then
   new_major=$((initial_major + 1))
   new_minor=0


### PR DESCRIPTION
Closes #79

Instead of relying on a marketplace action, we now use bash script to compute a new version from the PR description. The new version is computed based on the existence of one of the following flags (proceeded by a #):
- major
- minor
- patch

#patch