### PR TITLE
Keep spaces and newline characters when sanitizing the commit message

### DIFF
--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -24,7 +24,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           source version
-          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${PR_BODY//[^a-zA-Z0-9#]/}")
+          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${PR_BODY//[^a-zA-Z0-9# $'\n']/}")
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
   update-version-file:

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -8,7 +8,7 @@ if [[ $# -ne 2 ]]; then
 fi
 
 initial_version=${1//[^0-9.]/}
-input_string=${2//[^a-zA-Z0-9#]/}
+input_string=${2//[^a-zA-Z0-9# $'\n']/}
 
 initial_major=$(echo "$initial_version" | cut -d'.' -f1)
 initial_minor=$(echo "$initial_version" | cut -d'.' -f2)


### PR DESCRIPTION
To reduce the [already unlikely chance of accidentally  setting a version bump #flag](https://github.com/KIT-MRT/arbitration_graphs/actions/runs/11955843697) in the sanitized version of the PR description even further, we now keep whitespaces and newline characters.

#patch