### PR TITLE
Link to tutorial GitHub page from main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ In this scene,
 
 ## Tutorial
 
-Follow our [Tutorial](./docs/Tutorial.md) and learn how to use the Arbitration Graphs library!  
+Follow our [Tutorial](https://kit-mrt.github.io/arbitration_graphs/docs/Tutorial) and learn how to use the Arbitration Graphs library!  
 It's based on this demo and guides you through all important concepts:
 
-0. [Introduction – start here!](./docs/Tutorial.md)
-1. [Implement your first behavior component](./docs/tasks/1_implement_behavior_component.md)
-2. [Extend the arbitration graph with that behavior](./docs/tasks/2_extend_arbitration_graph.md)
-3. [Learn about nested arbitration graphs](./docs/tasks/3_nested_arbitrators.md)
-4. [Arbitrate based on predicted utility](./docs/tasks/4_cost_arbitration.md)
-5. [Verify commands and add a fallback strategy](./docs/tasks/5_verification.md)
+1. [Introduction – start here!](https://kit-mrt.github.io/arbitration_graphs/docs/Tutorial)
+2. [Implement your first behavior component](https://kit-mrt.github.io/arbitration_graphs/docs/tasks/1_implement_behavior_component)
+3. [Extend the arbitration graph with that behavior](https://kit-mrt.github.io/arbitration_graphs/docs/tasks/2_extend_arbitration_graph)
+4. [Learn about nested arbitration graphs](https://kit-mrt.github.io/arbitration_graphs/docs/tasks/3_nested_arbitrators)
+5. [Arbitrate based on predicted utility](https://kit-mrt.github.io/arbitration_graphs/docs/tasks/4_cost_arbitration)
+6. [Verify commands and add a fallback strategy](https://kit-mrt.github.io/arbitration_graphs/docs/tasks/5_verification)
 
 
 ## Installation


### PR DESCRIPTION
This PR encourages reading the tutorial on our GitHub Page by changing the Readme links to GitHub pages URLs.

#patch