### PR TITLE
Fix broken links in the GitHub pages menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,9 @@ tagline: decision-making for robotics
 # Support collapsible details/summary sections
 markdown: CommonMarkGhPages
 
+# Uncomment this in a local setup, in order to test link compatibility with GitHub Pages
+# baseurl: /base
+
 commonmark:
   options: ["UNSAFE", "SMART", "FOOTNOTES"]
   extensions: ["strikethrough", "autolink", "table", "tagfilter"]

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -47,14 +47,14 @@
             {% if page.url == "/" %}
               {% assign classes = "active" %}
             {% endif %}
-            <li class="{{ classes }}"><a href="/">🢄 Main</a></li>
+            <li class="{{ classes }}"><a href={{ "/" | relative_url }}>🢄 Main</a></li>
 
             <!-- Tutorial Home -->
             {% assign classes = "" %}
             {% if page.url == "/docs/Tutorial.html" %}
               {% assign classes = "active" %}
             {% endif %}
-            <li class="{{ classes }}"><a href="/docs/Tutorial.html">⌂ Tutorial Home</a></li>
+            <li class="{{ classes }}"><a href={{ "/docs/Tutorial.html" | relative_url }}>⌂ Tutorial Home</a></li>
 
             <!-- Tutorial Tasks -->
             {% for sitepage in site.pages %}
@@ -64,7 +64,7 @@
                 {% if page.url == sitepage.url %}
                   {% assign classes = "active" %}
                 {% endif %}
-                <li class="{{ classes }}"><a href="{{ sitepage.url }}">{{ sitepage.menu_title }}</a></li>
+                <li class="{{ classes }}"><a href="{{ sitepage.url | relative_url }}">{{ sitepage.menu_title }}</a></li>
               {% endif %}
             {% endfor %}
           </ul>


### PR DESCRIPTION
This fixes broken tutorial menu links.

They had absolute links that worked on a local jekyll setup, but not on GitHub Pages with a `baseurl` other than `/`.

#patch