### PR TITLE
Only allow one release workflow at a time

### DIFF
--- a/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
+++ b/.github/workflows/bump-version-and-create-release-and-push-docker-images.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   compute-version:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
This makes sure that only one release workflow runs at a time, even if multiple PRs have been merged in close concession.
Running workflows won't be canceled; newer workflows will wait in line to run after the current one finishes.

See [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) for a full documentation of the utilized settings.

This closes #97 .

#patch