### PR TITLE
Add flag allowing the Pac-Man GUI to be resized

### DIFF
--- a/demo/include/utils/pacman_wrapper.hpp
+++ b/demo/include/utils/pacman_wrapper.hpp
@@ -45,6 +45,7 @@ private:
     bool pause_{false};
     bool quit_{false};
     bool renderPath_{false};
+    bool fullscreen_{false};
 };
 
 } // namespace utils

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -36,7 +36,7 @@ SDL::Window createWindow(int scaleFactor) {
                                                   SDL_WINDOWPOS_CENTERED,
                                                   tilesPx.x * scaleFactor,
                                                   tilesPx.y * scaleFactor,
-                                                  SDL_WINDOW_SHOWN))};
+                                                  SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE))};
 }
 
 SDL::Renderer createRendererAndSetLogicalSize(const SDL::Window& window) {

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -75,6 +75,15 @@ void PacmanWrapper::handleUserInput() {
                 renderPath_ = !renderPath_;
                 break;
             }
+            if (event.key.keysym.scancode == SDL_SCANCODE_F) {
+                fullscreen_ = !fullscreen_;
+                if (fullscreen_) {
+                    SDL_SetWindowFullscreen(window_.get(), SDL_WINDOW_FULLSCREEN);
+                } else {
+                    SDL_SetWindowFullscreen(window_.get(), 0);
+                }
+                break;
+            }
         }
     }
 }
@@ -117,6 +126,7 @@ void PacmanWrapper::printKeybindings() {
               << "\033[1;36m=====================================\033[0m\n"
               << "  \033[1;32mESC/Q\033[0m - Quit the demo\n"
               << "  \033[1;32mSpace\033[0m - Pause the demo\n"
+              << "  \033[1;32mF\033[0m     - Toggle fullscreen mode\n"
               << "  \033[1;32mP\033[0m     - Toggle path visualization\n"
               << "\033[1;36m=====================================\033[0m\n"
               << "  \033[1;32mGUI\033[0m   - Open http://localhost:8080\n"


### PR DESCRIPTION
This adds the `SDL_WINDOW_RESIZABLE`  flag when calling `SDL_CreateWindow` while starting the Pac-Man demo GUI.
With this flag, the window can be resized or e.g. snapped to the screen border like any other window.

See [here](https://wiki.libsdl.org/SDL2/SDL_CreateWindow#remarks) for documentation regarding the flag.

#patch