### PR TITLE
Handle exceptions in cost arbitrator and in active behavior components

### DIFF
--- a/include/arbitration_graphs/cost_arbitrator.hpp
+++ b/include/arbitration_graphs/cost_arbitrator.hpp
@@ -116,14 +116,19 @@ private:
 
             const bool isActive = this->isActive(option);
 
-            double cost;
+            std::optional<SubCommandT> command;
             if (isActive) {
-                cost = option->costEstimator_->estimateCost(option->getCommand(time), isActive);
+                command = this->getAndVerifyCommand(option, time);
             } else {
                 option->behavior_->gainControl(time);
-                cost = option->costEstimator_->estimateCost(option->getCommand(time), isActive);
+                command = this->getAndVerifyCommand(option, time);
                 option->behavior_->loseControl(time);
             }
+            if (!command) {
+                continue;
+            }
+
+            double cost = option->costEstimator_->estimateCost(command.value(), isActive);
             option->last_estimated_cost_ = cost;
             sortedOptionsMap.insert({cost, option});
         }

--- a/include/arbitration_graphs/internal/arbitrator_impl.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_impl.hpp
@@ -68,6 +68,11 @@ std::optional<SubCommandT> Arbitrator<CommandT, SubCommandT, VerifierT, Verifica
         option->verificationResult_.reset();
 
         VLOG(1) << "Given option " << option->behavior_->name_ << " is an arbitrator without safe applicable option";
+        // Catch all other exceptions and cache failed verification result
+    } catch (const std::exception& e) {
+        option->verificationResult_.cache(time, VerificationResultT{false});
+        VLOG(1) << "Given option " << option->behavior_->name_ << " threw an exception during getAndVerifyCommand(): "
+                << e.what();
     }
     return std::nullopt;
 }

--- a/include/arbitration_graphs/internal/arbitrator_impl.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_impl.hpp
@@ -68,11 +68,11 @@ std::optional<SubCommandT> Arbitrator<CommandT, SubCommandT, VerifierT, Verifica
         option->verificationResult_.reset();
 
         VLOG(1) << "Given option " << option->behavior_->name_ << " is an arbitrator without safe applicable option";
-        // Catch all other exceptions and cache failed verification result
     } catch (const std::exception& e) {
+        // Catch all other exceptions and cache failed verification result
         option->verificationResult_.cache(time, VerificationResultT{false});
-        VLOG(1) << "Given option " << option->behavior_->name_ << " threw an exception during getAndVerifyCommand(): "
-                << e.what();
+        VLOG(1) << "Given option " << option->behavior_->name_
+                << " threw an exception during getAndVerifyCommand(): " << e.what();
     }
     return std::nullopt;
 }

--- a/include/arbitration_graphs/internal/arbitrator_impl.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_impl.hpp
@@ -109,17 +109,9 @@ SubCommandT Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::g
         }
         // otherwise we have bestOption == activeBehavior_ which already gained control
 
-        // an arbitrator as option might not return a command, if its applicable options fail verification:
-        std::optional<SubCommandT> command;
-        try {
-            command = getAndVerifyCommand(bestOption, time);
-        } catch (const std::exception& e) {
-            VLOG(1) << bestOption->behavior_->name_ << " threw an exception during getAndVerifyCommand(): " << e.what();
-            bestOption->verificationResult_.cache(time, VerificationResultT{false});
-            bestOption->behavior_->loseControl(time);
-            continue;
-        }
-
+        // an arbitrator as option might not return a command,
+        // if its applicable options fail verification or throw an exception:
+        const std::optional<SubCommandT> command = getAndVerifyCommand(bestOption, time);
         if (command) {
             if (activeBehavior_ && bestOption != activeBehavior_) {
                 // finally, prevent two behaviors from having control

--- a/test/dummy_types.hpp
+++ b/test/dummy_types.hpp
@@ -66,12 +66,23 @@ public:
 
 class BrokenDummyBehavior : public DummyBehavior {
 public:
-    BrokenDummyBehavior(const bool invocation, const bool commitment, const std::string& name = "BrokenDummyBehavior")
-            : DummyBehavior(invocation, commitment, name){};
+    BrokenDummyBehavior(const bool invocation,
+                        const bool commitment,
+                        const std::string& name = "BrokenDummyBehavior",
+                        int numGetCommandsUntilThrow = 0)
+            : DummyBehavior(invocation, commitment, name), numGetCommandsUntilThrow_{numGetCommandsUntilThrow} {};
 
     DummyCommand getCommand(const Time& time) override {
-        throw std::runtime_error("BrokenDummyBehavior::getCommand() is broken");
+        if (getCommandCounter_ >= numGetCommandsUntilThrow_) {
+            throw std::runtime_error("BrokenDummyBehavior::getCommand() is broken");
+        }
+
+        getCommandCounter_++;
+        return name_;
     }
+
+private:
+    int numGetCommandsUntilThrow_;
 };
 
 struct DummyResult : public verification::PlaceboResult {};

--- a/test/handle_exceptions.cpp
+++ b/test/handle_exceptions.cpp
@@ -46,3 +46,40 @@ TEST(ExceptionHandlingTest, HandleExceptionInPriorityArbitrator) {
     // With no fallback, there is no option to call even if the invocation condition is true
     EXPECT_THROW(testPriorityArbitrator.getCommand(time), NoApplicableOptionPassedVerificationError);
 }
+
+TEST(ExceptionHandlingTest, HandleExceptionInCommitedBehavior) {
+    using OptionFlags = PriorityArbitrator<DummyCommand>::Option::Flags;
+
+    // This behavior will only throw on the 2nd invocation
+    BrokenDummyBehavior::Ptr testBehaviorHighPriority =
+        std::make_shared<BrokenDummyBehavior>(true, true, "HighPriority", 1);
+    DummyBehavior::Ptr testBehaviorLowPriority = std::make_shared<DummyBehavior>(true, true, "LowPriority");
+
+    Time time{Clock::now()};
+
+    PriorityArbitrator<DummyCommand> testPriorityArbitrator;
+
+    testPriorityArbitrator.addOption(testBehaviorHighPriority, OptionFlags::NO_FLAGS);
+    testPriorityArbitrator.addOption(testBehaviorLowPriority, OptionFlags::NO_FLAGS);
+
+    ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time));
+
+    testPriorityArbitrator.gainControl(time);
+
+    // On the first call, the high priority behavior should be selected like it normally would
+    EXPECT_EQ("HighPriority", testPriorityArbitrator.getCommand(time));
+    ASSERT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    EXPECT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
+
+    // Progress time to not retreive cached commands
+    time += Duration(1);
+
+    // On the second call, the high priority behavior will throw an exception
+    // The arbitrator should catch the exception and fall back to the low priority behavior
+    EXPECT_EQ("LowPriority", testPriorityArbitrator.getCommand(time));
+    ASSERT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
+    ASSERT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
+
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time)->isOk());
+}

--- a/test/handle_exceptions.cpp
+++ b/test/handle_exceptions.cpp
@@ -10,17 +10,14 @@
 using namespace arbitration_graphs;
 using namespace arbitration_graphs_tests;
 
-class ExceptionHandlingTest : public ::testing::Test {
-protected:
+TEST(ExceptionHandlingTest, HandleExceptionInPriorityArbitrator) {
+    using OptionFlags = PriorityArbitrator<DummyCommand>::Option::Flags;
+
     BrokenDummyBehavior::Ptr testBehaviorHighPriority =
         std::make_shared<BrokenDummyBehavior>(true, true, "HighPriority");
     DummyBehavior::Ptr testBehaviorLowPriority = std::make_shared<DummyBehavior>(true, true, "LowPriority");
 
     Time time{Clock::now()};
-};
-
-TEST_F(ExceptionHandlingTest, HandleException) {
-    using OptionFlags = PriorityArbitrator<DummyCommand>::Option::Flags;
 
     PriorityArbitrator<DummyCommand> testPriorityArbitrator;
 
@@ -49,4 +46,3 @@ TEST_F(ExceptionHandlingTest, HandleException) {
     // With no fallback, there is no option to call even if the invocation condition is true
     EXPECT_THROW(testPriorityArbitrator.getCommand(time), NoApplicableOptionPassedVerificationError);
 }
-

--- a/test/verification.cpp
+++ b/test/verification.cpp
@@ -246,7 +246,7 @@ TEST_F(CommandVerificationTest, DummyVerifierInCostArbitrator) {
     std::string expectedPrintout = invocationTrueString + commitmentTrueString + "CostArbitrator\n"
                         "    - (cost:  n.a.) " + invocationFalseString + commitmentFalseString + "HighPriority\n"
                         "    - (cost:  n.a.) " + invocationFalseString + commitmentFalseString + "HighPriority\n"
-                        "    - (cost: 0.500) " + strikeThroughOn
+                        "    - (cost:  n.a.) " + strikeThroughOn
                                   + invocationTrueString + commitmentFalseString + "MidPriority"
                                   + strikeThroughOff + "\n"
                         " -> - (cost: 1.000) " + invocationTrueString + commitmentTrueString + "LowPriority";


### PR DESCRIPTION
This fixes some issue not quite covered by https://github.com/KIT-MRT/arbitration_graphs/pull/53 regarding exceptions thrown during a call to `getCommand`.

https://github.com/KIT-MRT/arbitration_graphs/pull/53 works well in most cases but two cases are not covered:
1. The cost arbitrator will call `getCommand` for all its options during `sortOptionsByGivenPolicy`. If an exception is thrown there, it was not handled. This caused the entire cost arbitrator to throw an exception. If the cost arbitrator was the child of a higher-level arbitrator, the exception was then handled there so the fallback engaged one level higher than expected.
2. A committed, non-interruptible behavior wouldn't be called via `getAndVerifyCommandFromApplicable` but instead via `getAndVerifyCommandFromActive`. If a behavior threw an exception at some point after it committed, the exception was not caught at all.

The solution contributed by this PR moves the exception handling down one layer into `getAndVerifyCommand` which is called by both `getAndVerifyCommandFromApplicable` and `getAndVerifyCommandFromActive`. Additionally, the cost arbitrator will now call `getAndVerifyCommand` while sorting its options, skipping options that throw an exception (and therefore do not return a command).

#patch