### PR TITLE
Add fix to clang-tidy to keep abstract classes minimalistic

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -167,3 +167,10 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.InlineNamespaceCase
     value:           lower_case
+
+  ########################
+  ### Abstract classes ###
+  ########################
+  # See https://github.com/llvm/llvm-project/issues/31206 for reference
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           1

--- a/demo/.clang-tidy
+++ b/demo/.clang-tidy
@@ -167,3 +167,10 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.InlineNamespaceCase
     value:           lower_case
+
+  ########################
+  ### Abstract classes ###
+  ########################
+  # See https://github.com/llvm/llvm-project/issues/31206 for reference
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           1


### PR DESCRIPTION
This fixes a linter issue when defining abstract classes.

---

Here's a full explanation of what's happening and why this change is necessary:

As soon as a class definition introduces virtual classes, the cpp core guidelines demands that
> A base class destructor should be either public and virtual, or protected and non-virtual ([reference](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual))
This is to prevent undefined behavior when attempting to destroy a derived class object through a base class pointer

However, when implementing that, clang-tidy now complains about the "the rule of five": 
> If you define or =delete any copy, move, or destructor function, define or =delete them all ([reference](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all))

This then contradicts "the rule of zero"
> If you can avoid defining default operations, do ([reference](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do))

We therefore allow classes to only define a destructor without having to follow the rule of five. To satisfy the linter without this change, a simple abstract class would look like this:

```cpp
class AbstractClass {
public:
    virtual ~AbstractClass() = default;

    AbstractClass() = default;
    AbstractClass(const AbstractResult&) = default;
    AbstractClass& operator=(const AbstractResult&) = default;
    AbstractClass(AbstractResult&&) = default;
    AbstractClass& operator=(AbstractResult&&) = default;

    virtual void someCommonInterface() = 0;
};
```

whereas now we can write:

```cpp
class AbstractClass {
public:
    virtual ~AbstractClass() = default;

    virtual void someCommonInterface() = 0;
};


```

See https://github.com/llvm/llvm-project/issues/31206 for a discussion about this issue coming to the same conclusion.

#patch