### PR TITLE
Use abstract verifier class in core library

### DIFF
--- a/include/arbitration_graphs/arbitrator.hpp
+++ b/include/arbitration_graphs/arbitrator.hpp
@@ -104,7 +104,7 @@ public:
 
     Arbitrator(const std::string& name = "Arbitrator",
                VerifierPtr verifier = std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
-            : Behavior<CommandT>(name), verifier_{std::move(verifier)} {};
+            : Behavior<CommandT>(name), verifier_(verifier) {};
 
 
     virtual void addOption(const typename Behavior<SubCommandT>::Ptr& behavior, const typename Option::FlagsT& flags) {

--- a/include/arbitration_graphs/arbitrator.hpp
+++ b/include/arbitration_graphs/arbitrator.hpp
@@ -57,7 +57,7 @@ public:
         typename Behavior<SubCommandT>::Ptr behavior_;
         FlagsT flags_;
         mutable util_caching::Cache<Time, SubCommandT> command_;
-        mutable util_caching::Cache<Time, verification::AbstractResult::Ptr> verificationResult_;
+        mutable util_caching::Cache<Time, verification::AbstractResult::ConstPtr> verificationResult_;
 
         SubCommandT getCommand(const Time& time) const {
             if (!command_.cached(time)) {

--- a/include/arbitration_graphs/arbitrator.hpp
+++ b/include/arbitration_graphs/arbitrator.hpp
@@ -32,6 +32,8 @@ public:
     using Ptr = std::shared_ptr<Arbitrator>;
     using ConstPtr = std::shared_ptr<const Arbitrator>;
 
+    using VerifierPtr = std::shared_ptr<verification::AbstractVerifier<SubCommandT>>;
+
     /*!
      * \brief The Option struct holds a behavior option of the arbitrator and corresponding flags
      *
@@ -101,8 +103,7 @@ public:
 
 
     Arbitrator(const std::string& name = "Arbitrator",
-               typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
-                   std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+               VerifierPtr verifier = std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
             : Behavior<CommandT>(name), verifier_{std::move(verifier)} {};
 
 

--- a/include/arbitration_graphs/arbitrator.hpp
+++ b/include/arbitration_graphs/arbitrator.hpp
@@ -25,14 +25,8 @@ namespace arbitration_graphs {
  * \note If CommandT != SubCommandT either
  *       - override getCommand() in your specialized Arbitrator or
  *       - provide a CommandT(const SubCommandT&) constructor
- *
- * \note As long as VerifierT::analyze() is static the VerificationResultT type can be deduced by the compiler,
- *       otherwise you have to pass it as template argument
  */
-template <typename CommandT,
-          typename SubCommandT = CommandT,
-          typename VerifierT = verification::PlaceboVerifier<SubCommandT>,
-          typename VerificationResultT = typename decltype(std::function{VerifierT::analyze})::result_type>
+template <typename CommandT, typename SubCommandT = CommandT>
 class Arbitrator : public Behavior<CommandT> {
 public:
     using Ptr = std::shared_ptr<Arbitrator>;
@@ -63,7 +57,7 @@ public:
         typename Behavior<SubCommandT>::Ptr behavior_;
         FlagsT flags_;
         mutable util_caching::Cache<Time, SubCommandT> command_;
-        mutable util_caching::Cache<Time, VerificationResultT> verificationResult_;
+        mutable util_caching::Cache<Time, verification::AbstractResult::Ptr> verificationResult_;
 
         SubCommandT getCommand(const Time& time) const {
             if (!command_.cached(time)) {
@@ -106,8 +100,10 @@ public:
     using ConstOptions = std::vector<typename Option::ConstPtr>;
 
 
-    Arbitrator(const std::string& name = "Arbitrator", const VerifierT& verifier = VerifierT())
-            : Behavior<CommandT>(name), verifier_{verifier} {};
+    Arbitrator(const std::string& name = "Arbitrator",
+               typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
+                   std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+            : Behavior<CommandT>(name), verifier_{std::move(verifier)} {};
 
 
     virtual void addOption(const typename Behavior<SubCommandT>::Ptr& behavior, const typename Option::FlagsT& flags) {
@@ -253,7 +249,7 @@ protected:
     Options behaviorOptions_;
     typename Option::Ptr activeBehavior_;
 
-    VerifierT verifier_;
+    typename verification::AbstractVerifier<SubCommandT>::Ptr verifier_;
 };
 } // namespace arbitration_graphs
 

--- a/include/arbitration_graphs/cost_arbitrator.hpp
+++ b/include/arbitration_graphs/cost_arbitrator.hpp
@@ -20,13 +20,10 @@ struct CostEstimator {
     virtual double estimateCost(const SubCommandT& command, const bool isActive) = 0;
 };
 
-template <typename CommandT,
-          typename SubCommandT = CommandT,
-          typename VerifierT = verification::PlaceboVerifier<SubCommandT>,
-          typename VerificationResultT = typename decltype(std::function{VerifierT::analyze})::result_type>
-class CostArbitrator : public Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT> {
+template <typename CommandT, typename SubCommandT = CommandT>
+class CostArbitrator : public Arbitrator<CommandT, SubCommandT> {
 public:
-    using ArbitratorBase = Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>;
+    using ArbitratorBase = Arbitrator<CommandT, SubCommandT>;
 
     using Ptr = std::shared_ptr<CostArbitrator>;
     using ConstPtr = std::shared_ptr<const CostArbitrator>;
@@ -75,7 +72,9 @@ public:
     };
 
 
-    CostArbitrator(const std::string& name = "CostArbitrator", const VerifierT& verifier = VerifierT())
+    CostArbitrator(const std::string& name = "CostArbitrator",
+                   typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
+                       std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
             : ArbitratorBase(name, verifier) {};
 
 

--- a/include/arbitration_graphs/cost_arbitrator.hpp
+++ b/include/arbitration_graphs/cost_arbitrator.hpp
@@ -28,6 +28,8 @@ public:
     using Ptr = std::shared_ptr<CostArbitrator>;
     using ConstPtr = std::shared_ptr<const CostArbitrator>;
 
+    using VerifierPtr = std::shared_ptr<verification::AbstractVerifier<SubCommandT>>;
+
     struct Option : ArbitratorBase::Option {
         using Ptr = std::shared_ptr<Option>;
         using FlagsT = typename ArbitratorBase::Option::FlagsT;
@@ -73,8 +75,7 @@ public:
 
 
     CostArbitrator(const std::string& name = "CostArbitrator",
-                   typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
-                       std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+                   VerifierPtr verifier = std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
             : ArbitratorBase(name, verifier) {};
 
 

--- a/include/arbitration_graphs/internal/arbitrator_impl.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_impl.hpp
@@ -48,7 +48,7 @@ std::optional<SubCommandT> Arbitrator<CommandT, SubCommandT>::getAndVerifyComman
     try {
         const SubCommandT command = option->getCommand(time);
 
-        verification::AbstractResult::Ptr verificationResult = verifier_->analyze(time, command);
+        const verification::AbstractResult::ConstPtr verificationResult = verifier_->analyze(time, command);
         option->verificationResult_.cache(time, verificationResult);
 
         // options explicitly flagged as fallback do not need to pass verification

--- a/include/arbitration_graphs/internal/arbitrator_io.hpp
+++ b/include/arbitration_graphs/internal/arbitrator_io.hpp
@@ -9,15 +9,14 @@ namespace arbitration_graphs {
 //    Arbitrator::Option    //
 //////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-std::ostream& Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::to_stream(
-    std::ostream& output,
-    const Time& time,
-    const int& option_index,
-    const std::string& prefix,
-    const std::string& suffix) const {
+template <typename CommandT, typename SubCommandT>
+std::ostream& Arbitrator<CommandT, SubCommandT>::Option::to_stream(std::ostream& output,
+                                                                   const Time& time,
+                                                                   const int& option_index,
+                                                                   const std::string& prefix,
+                                                                   const std::string& suffix) const {
 
-    if (verificationResult_.cached(time) && !verificationResult_.cached(time)->isOk()) {
+    if (verificationResult_.cached(time) && !verificationResult_.cached(time).value()->isOk()) {
         // ANSI backspace: \010
         // ANSI strikethrough on: \033[9m
         output << "×××\010\010\010\033[9m";
@@ -33,13 +32,13 @@ std::ostream& Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>:
     return output;
 }
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::toYaml(const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node Arbitrator<CommandT, SubCommandT>::Option::toYaml(const Time& time) const {
     YAML::Node node;
     node["type"] = "Option";
     node["behavior"] = behavior_->toYaml(time);
     if (verificationResult_.cached(time)) {
-        node["verificationResult"] = verificationResult_.cached(time)->isOk() ? "passed" : "failed";
+        node["verificationResult"] = verificationResult_.cached(time).value()->isOk() ? "passed" : "failed";
     }
     if (hasFlag(Option::Flags::INTERRUPTABLE)) {
         node["flags"].push_back("INTERRUPTABLE");
@@ -56,9 +55,11 @@ YAML::Node Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Op
 //        Arbitrator        //
 //////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-std::ostream& Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::to_stream(
-    std::ostream& output, const Time& time, const std::string& prefix, const std::string& suffix) const {
+template <typename CommandT, typename SubCommandT>
+std::ostream& Arbitrator<CommandT, SubCommandT>::to_stream(std::ostream& output,
+                                                           const Time& time,
+                                                           const std::string& prefix,
+                                                           const std::string& suffix) const {
 
     Behavior<CommandT>::to_stream(output, time, prefix, suffix);
 
@@ -76,8 +77,8 @@ std::ostream& Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>:
     return output;
 }
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::toYaml(const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node Arbitrator<CommandT, SubCommandT>::toYaml(const Time& time) const {
     YAML::Node node = Behavior<CommandT>::toYaml(time);
 
     node["type"] = "Arbitrator";

--- a/include/arbitration_graphs/internal/cost_arbitrator_io.hpp
+++ b/include/arbitration_graphs/internal/cost_arbitrator_io.hpp
@@ -9,13 +9,12 @@ namespace arbitration_graphs {
 //    CostArbitrator::Option    //
 //////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-std::ostream& CostArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::to_stream(
-    std::ostream& output,
-    const Time& time,
-    const int& option_index,
-    const std::string& prefix,
-    const std::string& suffix) const {
+template <typename CommandT, typename SubCommandT>
+std::ostream& CostArbitrator<CommandT, SubCommandT>::Option::to_stream(std::ostream& output,
+                                                                       const Time& time,
+                                                                       const int& option_index,
+                                                                       const std::string& prefix,
+                                                                       const std::string& suffix) const {
 
     if (last_estimated_cost_) {
         output << std::fixed << std::setprecision(3) << "- (cost: " << *last_estimated_cost_ << ") ";
@@ -27,9 +26,8 @@ std::ostream& CostArbitrator<CommandT, SubCommandT, VerifierT, VerificationResul
     return output;
 }
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node CostArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::toYaml(
-    const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node CostArbitrator<CommandT, SubCommandT>::Option::toYaml(const Time& time) const {
     YAML::Node node = ArbitratorBase::Option::toYaml(time);
     if (last_estimated_cost_) {
         node["cost"] = *last_estimated_cost_;
@@ -42,8 +40,8 @@ YAML::Node CostArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>
 //        CostArbitrator        //
 //////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node CostArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::toYaml(const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node CostArbitrator<CommandT, SubCommandT>::toYaml(const Time& time) const {
     YAML::Node node = ArbitratorBase::toYaml(time);
 
     node["type"] = "CostArbitrator";

--- a/include/arbitration_graphs/internal/priority_arbitrator_io.hpp
+++ b/include/arbitration_graphs/internal/priority_arbitrator_io.hpp
@@ -10,13 +10,12 @@ namespace arbitration_graphs {
 //    PriorityArbitrator::Option    //
 //////////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-std::ostream& PriorityArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::to_stream(
-    std::ostream& output,
-    const Time& time,
-    const int& option_index,
-    const std::string& prefix,
-    const std::string& suffix) const {
+template <typename CommandT, typename SubCommandT>
+std::ostream& PriorityArbitrator<CommandT, SubCommandT>::Option::to_stream(std::ostream& output,
+                                                                           const Time& time,
+                                                                           const int& option_index,
+                                                                           const std::string& prefix,
+                                                                           const std::string& suffix) const {
 
     output << option_index + 1 << ". ";
     ArbitratorBase::Option::to_stream(output, time, option_index, prefix, suffix);
@@ -28,8 +27,8 @@ std::ostream& PriorityArbitrator<CommandT, SubCommandT, VerifierT, VerificationR
 //        PriorityArbitrator        //
 //////////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node PriorityArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::toYaml(const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node PriorityArbitrator<CommandT, SubCommandT>::toYaml(const Time& time) const {
     YAML::Node node = ArbitratorBase::toYaml(time);
     node["type"] = "PriorityArbitrator";
     return node;

--- a/include/arbitration_graphs/internal/random_arbitrator_io.hpp
+++ b/include/arbitration_graphs/internal/random_arbitrator_io.hpp
@@ -10,13 +10,12 @@ namespace arbitration_graphs {
 //    RandomArbitrator::Option    //
 //////////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-std::ostream& RandomArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::Option::to_stream(
-    std::ostream& output,
-    const Time& time,
-    const int& option_index,
-    const std::string& prefix,
-    const std::string& suffix) const {
+template <typename CommandT, typename SubCommandT>
+std::ostream& RandomArbitrator<CommandT, SubCommandT>::Option::to_stream(std::ostream& output,
+                                                                         const Time& time,
+                                                                         const int& option_index,
+                                                                         const std::string& prefix,
+                                                                         const std::string& suffix) const {
 
     output << std::fixed << std::setprecision(3) << "- (weight: " << weight_ << ") ";
     ArbitratorBase::Option::to_stream(output, time, option_index, prefix, suffix);
@@ -28,8 +27,8 @@ std::ostream& RandomArbitrator<CommandT, SubCommandT, VerifierT, VerificationRes
 //        RandomArbitrator        //
 //////////////////////////////////////
 
-template <typename CommandT, typename SubCommandT, typename VerifierT, typename VerificationResultT>
-YAML::Node RandomArbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>::toYaml(const Time& time) const {
+template <typename CommandT, typename SubCommandT>
+YAML::Node RandomArbitrator<CommandT, SubCommandT>::toYaml(const Time& time) const {
     YAML::Node node = ArbitratorBase::toYaml(time);
     node["type"] = "RandomArbitrator";
     return node;

--- a/include/arbitration_graphs/priority_arbitrator.hpp
+++ b/include/arbitration_graphs/priority_arbitrator.hpp
@@ -18,6 +18,8 @@ public:
     using Ptr = std::shared_ptr<PriorityArbitrator>;
     using ConstPtr = std::shared_ptr<const PriorityArbitrator>;
 
+    using VerifierPtr = std::shared_ptr<verification::AbstractVerifier<SubCommandT>>;
+
     struct Option : public ArbitratorBase::Option {
     public:
         using Ptr = std::shared_ptr<Option>;
@@ -50,8 +52,7 @@ public:
     };
 
     PriorityArbitrator(const std::string& name = "PriorityArbitrator",
-                       typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
-                           std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+                       VerifierPtr verifier = std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
             : ArbitratorBase(name, verifier) {};
 
     void addOption(const typename Behavior<SubCommandT>::Ptr& behavior, const typename Option::FlagsT& flags) {

--- a/include/arbitration_graphs/priority_arbitrator.hpp
+++ b/include/arbitration_graphs/priority_arbitrator.hpp
@@ -10,13 +10,10 @@
 
 namespace arbitration_graphs {
 
-template <typename CommandT,
-          typename SubCommandT = CommandT,
-          typename VerifierT = verification::PlaceboVerifier<SubCommandT>,
-          typename VerificationResultT = typename decltype(std::function{VerifierT::analyze})::result_type>
-class PriorityArbitrator : public Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT> {
+template <typename CommandT, typename SubCommandT = CommandT>
+class PriorityArbitrator : public Arbitrator<CommandT, SubCommandT> {
 public:
-    using ArbitratorBase = Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>;
+    using ArbitratorBase = Arbitrator<CommandT, SubCommandT>;
 
     using Ptr = std::shared_ptr<PriorityArbitrator>;
     using ConstPtr = std::shared_ptr<const PriorityArbitrator>;
@@ -52,8 +49,10 @@ public:
                                         const std::string& suffix = "") const;
     };
 
-    PriorityArbitrator(const std::string& name = "PriorityArbitrator", const VerifierT& verifier = VerifierT())
-            : ArbitratorBase(name, verifier){};
+    PriorityArbitrator(const std::string& name = "PriorityArbitrator",
+                       typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
+                           std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+            : ArbitratorBase(name, verifier) {};
 
     void addOption(const typename Behavior<SubCommandT>::Ptr& behavior, const typename Option::FlagsT& flags) {
         typename Option::Ptr option = std::make_shared<Option>(behavior, flags);

--- a/include/arbitration_graphs/random_arbitrator.hpp
+++ b/include/arbitration_graphs/random_arbitrator.hpp
@@ -17,6 +17,8 @@ public:
     using Ptr = std::shared_ptr<RandomArbitrator>;
     using ConstPtr = std::shared_ptr<const RandomArbitrator>;
 
+    using VerifierPtr = std::shared_ptr<verification::AbstractVerifier<SubCommandT>>;
+
     struct Option : public ArbitratorBase::Option {
     public:
         using Ptr = std::shared_ptr<Option>;
@@ -54,8 +56,7 @@ public:
     using Options = std::vector<typename Option::Ptr>;
 
     RandomArbitrator(const std::string& name = "RandomArbitrator",
-                     typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
-                         std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+                     VerifierPtr verifier = std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
             : ArbitratorBase(name, verifier) {};
 
     void addOption(const typename Behavior<SubCommandT>::Ptr& behavior,

--- a/include/arbitration_graphs/random_arbitrator.hpp
+++ b/include/arbitration_graphs/random_arbitrator.hpp
@@ -9,13 +9,10 @@
 
 namespace arbitration_graphs {
 
-template <typename CommandT,
-          typename SubCommandT = CommandT,
-          typename VerifierT = verification::PlaceboVerifier<SubCommandT>,
-          typename VerificationResultT = typename decltype(std::function{VerifierT::analyze})::result_type>
-class RandomArbitrator : public Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT> {
+template <typename CommandT, typename SubCommandT = CommandT>
+class RandomArbitrator : public Arbitrator<CommandT, SubCommandT> {
 public:
-    using ArbitratorBase = Arbitrator<CommandT, SubCommandT, VerifierT, VerificationResultT>;
+    using ArbitratorBase = Arbitrator<CommandT, SubCommandT>;
 
     using Ptr = std::shared_ptr<RandomArbitrator>;
     using ConstPtr = std::shared_ptr<const RandomArbitrator>;
@@ -56,8 +53,10 @@ public:
     };
     using Options = std::vector<typename Option::Ptr>;
 
-    RandomArbitrator(const std::string& name = "RandomArbitrator", const VerifierT& verifier = VerifierT())
-            : ArbitratorBase(name, verifier){};
+    RandomArbitrator(const std::string& name = "RandomArbitrator",
+                     typename verification::AbstractVerifier<SubCommandT>::Ptr verifier =
+                         std::make_shared<verification::PlaceboVerifier<SubCommandT>>())
+            : ArbitratorBase(name, verifier) {};
 
     void addOption(const typename Behavior<SubCommandT>::Ptr& behavior,
                    const typename Option::FlagsT& flags,

--- a/include/arbitration_graphs/verification.hpp
+++ b/include/arbitration_graphs/verification.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <ostream>
 
 #include "types.hpp"
@@ -7,23 +8,48 @@
 
 namespace arbitration_graphs::verification {
 
+class AbstractResult {
+public:
+    using Ptr = std::shared_ptr<AbstractResult>;
+    using ConstPtr = std::shared_ptr<const AbstractResult>;
+
+    virtual ~AbstractResult() = default;
+
+    virtual bool isOk() const = 0;
+};
+
+template <typename DataT>
+class AbstractVerifier {
+public:
+    using Ptr = std::shared_ptr<AbstractVerifier<DataT>>;
+    using ConstPtr = std::shared_ptr<const AbstractVerifier<DataT>>;
+
+    virtual ~AbstractVerifier() = default;
+
+    virtual AbstractResult::Ptr analyze(const Time& time, const DataT& data) const = 0;
+};
+
 /*!
  * @brief The PlaceboResult is always okay, thus is the PlaceboVerifier a placebo (you probably guessed it).
  *
  * Use this together with PlaceboVerifier, if you don't care to verify your commands before dumping them onto your
  * robots. Otherwise these are a good starting point to implement your own meaningful verifier.
  */
-struct PlaceboResult {
-    bool isOk() const {
+class PlaceboResult : public AbstractResult {
+public:
+    explicit PlaceboResult(bool isOk = true) : isOk_(isOk) {
+    }
+    bool isOk() const override {
         return isOk_;
     };
 
+private:
     bool isOk_{true};
 };
 template <typename DataT>
-struct PlaceboVerifier {
-    static PlaceboResult analyze(const Time& /*time*/, const DataT& /*data*/) {
-        return PlaceboResult();
+struct PlaceboVerifier : public AbstractVerifier<DataT> {
+    AbstractResult::Ptr analyze(const Time& /*time*/, const DataT& /*data*/) const override {
+        return std::make_shared<PlaceboResult>();
     };
 };
 
@@ -37,7 +63,7 @@ struct PlaceboVerifier {
  * std::cout << result << std::endl;
  * @endcode
  */
-inline std::ostream& operator<<(std::ostream& out, const arbitration_graphs::verification::PlaceboResult& result) {
+inline std::ostream& operator<<(std::ostream& out, const arbitration_graphs::verification::AbstractResult& result) {
     out << (result.isOk() ? "is okay" : "is not okay");
     return out;
 }

--- a/test/dummy_types.hpp
+++ b/test/dummy_types.hpp
@@ -85,7 +85,7 @@ private:
     int numGetCommandsUntilThrow_;
 };
 
-struct DummyResult : public verification::PlaceboResult {};
+using DummyResult = verification::PlaceboResult;
 
 } // namespace arbitration_graphs_tests
 

--- a/test/handle_exceptions.cpp
+++ b/test/handle_exceptions.cpp
@@ -34,8 +34,8 @@ TEST(ExceptionHandlingTest, HandleExceptionInPriorityArbitrator) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
-    EXPECT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time).value()->isOk());
 
     testPriorityArbitrator.loseControl(time);
 
@@ -70,7 +70,7 @@ TEST(ExceptionHandlingTest, HandleExceptionInCommitedBehavior) {
     // On the first call, the high priority behavior should be selected like it normally would
     EXPECT_EQ("HighPriority", testPriorityArbitrator.getCommand(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
-    EXPECT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time).value()->isOk());
 
     // Progress time to not retreive cached commands
     time += Duration(1);
@@ -81,8 +81,8 @@ TEST(ExceptionHandlingTest, HandleExceptionInCommitedBehavior) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
-    EXPECT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(1)->verificationResult_.cached(time).value()->isOk());
 }
 
 TEST(ExceptionHandlingTest, HandleExceptionsInCostArbitrator) {
@@ -111,6 +111,6 @@ TEST(ExceptionHandlingTest, HandleExceptionsInCostArbitrator) {
     ASSERT_TRUE(testCostArbitrator.options().at(0)->verificationResult_.cached(time));
     ASSERT_TRUE(testCostArbitrator.options().at(1)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testCostArbitrator.options().at(0)->verificationResult_.cached(time)->isOk());
-    EXPECT_TRUE(testCostArbitrator.options().at(1)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testCostArbitrator.options().at(0)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_TRUE(testCostArbitrator.options().at(1)->verificationResult_.cached(time).value()->isOk());
 }

--- a/test/verification.cpp
+++ b/test/verification.cpp
@@ -58,7 +58,7 @@ TEST_F(CommandVerificationTest, DefaultVerifier) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     // LowPriority could have been verified or not, so don't test it here
 
-    EXPECT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value()->isOk());
 }
 
 
@@ -83,7 +83,7 @@ TEST_F(CommandVerificationTest, PlaceboVerifier) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     // LowPriority could have been verified or not, so don't test it here
 
-    EXPECT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value()->isOk());
 }
 
 
@@ -109,8 +109,8 @@ TEST_F(CommandVerificationTest, DummyVerifierInPriorityArbitrator) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time));
     ASSERT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
-    EXPECT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time).value()->isOk());
 
     std::cout << "verificationResult for " << testPriorityArbitrator.options().at(2)->behavior_->name_ << ": "
               << testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value() << std::endl;
@@ -177,8 +177,8 @@ TEST_F(CommandVerificationTest, DummyVerifierInPriorityArbitratorWithFallback) {
     ASSERT_TRUE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time));
     EXPECT_FALSE(testPriorityArbitrator.options().at(4)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
-    EXPECT_FALSE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_FALSE(testPriorityArbitrator.options().at(3)->verificationResult_.cached(time).value()->isOk());
 
     std::cout << "verificationResult for " << testPriorityArbitrator.options().at(2)->behavior_->name_ << ": "
               << testPriorityArbitrator.options().at(2)->verificationResult_.cached(time).value() << std::endl;
@@ -238,8 +238,8 @@ TEST_F(CommandVerificationTest, DummyVerifierInCostArbitrator) {
     ASSERT_TRUE(testCostArbitrator.options().at(2)->verificationResult_.cached(time));
     ASSERT_TRUE(testCostArbitrator.options().at(3)->verificationResult_.cached(time));
 
-    EXPECT_FALSE(testCostArbitrator.options().at(2)->verificationResult_.cached(time)->isOk());
-    EXPECT_TRUE(testCostArbitrator.options().at(3)->verificationResult_.cached(time)->isOk());
+    EXPECT_FALSE(testCostArbitrator.options().at(2)->verificationResult_.cached(time).value()->isOk());
+    EXPECT_TRUE(testCostArbitrator.options().at(3)->verificationResult_.cached(time).value()->isOk());
 
     // clang-format off
     std::string expectedPrintout = invocationTrueString + commitmentTrueString + "CostArbitrator\n"


### PR DESCRIPTION
This implements the abstract verification class for the core library (c.f. #116)

This reduces the amount of required template parameters tidying up the code a little bit. It also simplifies how we can bind these classes via pybind.
Finally, it defines a very clear interface for both the result and verifier type as these are now pure virtual and have to be overwritten by a concrete implementations.

I created a separate branch `update-interfaces` that we can merge the separate breaking changes onto before merging back to main and updating the version.