### PR TITLE
Fix gui release test broken by new sigint test

### DIFF
--- a/gui/test/CMakeLists.txt
+++ b/gui/test/CMakeLists.txt
@@ -91,7 +91,7 @@ if(GTEST_FOUND)
 
     if(TEST_TARGET_NAME MATCHES "sigint")
       add_test(NAME ${TEST_TARGET_NAME}
-        COMMAND ${CMAKE_SOURCE_DIR}/gui/test/sigint_test.sh $<TARGET_FILE:${TEST_TARGET_NAME}>
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/sigint_test.sh $<TARGET_FILE:${TEST_TARGET_NAME}>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       )
     else()


### PR DESCRIPTION
This fixes a the gui release CI #122 that has been broken by #120 
New docker images should be published by the CI again.

#patch