### PR TITLE
Use local repo in cibuildwheel

### DIFF
--- a/python_bindings/Dockerfile
+++ b/python_bindings/Dockerfile
@@ -86,13 +86,17 @@ RUN git clone https://github.com/KIT-MRT/util_caching.git && \
     rm -rf util_caching
 
 # Build arbitration_graphs
-RUN git clone https://github.com/KIT-MRT/arbitration_graphs.git && \
-    cd arbitration_graphs && \
-    mkdir build && \
-    cd build && \
-    cmake -DBUILD_GUI=false .. && \
-    make && \
-    make install && \
-    cd ../.. && \
-    rm -rf arbitration_graphs
+COPY cmake /tmp/arbitration_graphs/cmake
+COPY CMakeLists.txt /tmp/arbitration_graphs/
+COPY include /tmp/arbitration_graphs/include
+COPY LICENSE /tmp/arbitration_graphs/
+COPY README.md /tmp/arbitration_graphs/
+COPY version /tmp/arbitration_graphs/
+
+WORKDIR /tmp/arbitration_graphs/build
+
+RUN cmake -DBUILD_GUI=false .. && \
+    cmake --build . && \
+    cmake --install . && \
+    rm -rf /tmp/arbitration_graphs
 

--- a/python_bindings/Dockerfile
+++ b/python_bindings/Dockerfile
@@ -64,26 +64,24 @@ RUN yum update -y && \
     yum clean all
 
 # Build glog from source to get up-to-date version that can be found without FindGlog.cmake
-RUN git clone https://github.com/google/glog.git && \
-    cd glog && \
+RUN git clone https://github.com/google/glog.git /tmp/glog && \
+    cd /tmp/glog && \
     mkdir build && \
     cd build && \
     cmake -DBUILD_SHARED_LIBS=OFF .. && \
-    make && \
-    make install && \
-    cd ../.. && \
-    rm -rf glog
+    cmake --build . && \
+    cmake --install . && \
+    rm -rf /tmp/glog
 
 # Build util_caching
-RUN git clone https://github.com/KIT-MRT/util_caching.git && \
-    cd util_caching && \
+RUN git clone https://github.com/KIT-MRT/util_caching.git /tmp/util_caching && \
+    cd /tmp/util_caching && \
     mkdir build && \
     cd build && \
     cmake .. && \
-    make && \
-    make install && \
-    cd ../.. && \
-    rm -rf util_caching
+    cmake --build . && \
+    cmake --install . && \
+    rm -rf /tmp/util_caching
 
 # Build arbitration_graphs
 COPY cmake /tmp/arbitration_graphs/cmake

--- a/python_bindings/docker-compose.yaml
+++ b/python_bindings/docker-compose.yaml
@@ -10,7 +10,8 @@ services:
 
   wheel_builder:
     build:
-      context: .
+      context: ..
+      dockerfile: python_bindings/Dockerfile
       target: wheel_builder
     image: arbitration_graphs_wheel_builder
 

--- a/python_bindings/scripts/cibuildwheel.sh
+++ b/python_bindings/scripts/cibuildwheel.sh
@@ -1,9 +1,9 @@
 #!/bin/env bash
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 cd $SCRIPT_DIR/..
 
-docker compose build wheel_builder
+docker compose build --pull wheel_builder
 
 # Temporary replace the symlinked version with a copy as the link can not be resolved inside the docker container
 rm version


### PR DESCRIPTION
This enforces that the python wheels will always use the matching
version of the arbitration_graph library by copying files from the local
repository rather than using git clone.

This will also cause the wheel builder image to be rebuilt if the arbitration
graph library is updated. A `git clone` would be cached and might lead
to out-of-date installs of the arbitration graph library.

#patch