### PR TITLE
Interface Update Demo: Add Environment Model

### DIFF
--- a/demo/include/demo/avoid_ghost_behavior.hpp
+++ b/demo/include/demo/avoid_ghost_behavior.hpp
@@ -14,7 +14,7 @@ namespace demo {
  * to him. It is applicable once a ghost is within a certain distance to Pacman. To prevent oscillating behavior
  * switches, the commitment condition should remain active for longer than the invocation condition.
  */
-class AvoidGhostBehavior : public arbitration_graphs::Behavior<Command> {
+class AvoidGhostBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<AvoidGhostBehavior>;
     using ConstPtr = std::shared_ptr<const AvoidGhostBehavior>;
@@ -24,19 +24,16 @@ public:
         double commitmentMinDistance{7};
     };
 
-    explicit AvoidGhostBehavior(EnvironmentModel::Ptr environmentModel,
-                                const Parameters& parameters,
-                                const std::string& name = "AvoidGhost")
-            : Behavior(name), environmentModel_{std::move(environmentModel)}, parameters_{parameters} {
+    explicit AvoidGhostBehavior(const Parameters& parameters, const std::string& name = "AvoidGhost")
+            : Behavior(name), parameters_{parameters} {
     }
 
     Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
     bool checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
-    bool checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
 
 private:
-    EnvironmentModel::Ptr environmentModel_;
     Parameters parameters_;
 };
 

--- a/demo/include/demo/avoid_ghost_behavior.hpp
+++ b/demo/include/demo/avoid_ghost_behavior.hpp
@@ -8,10 +8,10 @@
 namespace demo {
 
 /**
- * @brief The AvoidGhostBehavior makes Pacman run away from the closest ghost.
+ * @brief The AvoidGhostBehavior makes Pac-Man run away from the closest ghost.
  *
- * The behavior returns the command which increases the distance between Pacman and the ghost that's currently closest
- * to him. It is applicable once a ghost is within a certain distance to Pacman. To prevent oscillating behavior
+ * The behavior returns the command which increases the distance between Pac-Man and the ghost that's currently closest
+ * to him. It is applicable once a ghost is within a certain distance to Pac-Man. To prevent oscillating behavior
  * switches, the commitment condition should remain active for longer than the invocation condition.
  */
 class AvoidGhostBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {

--- a/demo/include/demo/avoid_ghost_behavior.hpp
+++ b/demo/include/demo/avoid_ghost_behavior.hpp
@@ -30,10 +30,10 @@ public:
             : Behavior(name), environmentModel_{std::move(environmentModel)}, parameters_{parameters} {
     }
 
-    Command getCommand(const Time& time) override;
+    Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& time) const override;
-    bool checkCommitmentCondition(const Time& time) const override;
+    bool checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const override;
 
 private:
     EnvironmentModel::Ptr environmentModel_;

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -9,7 +9,7 @@
 namespace demo {
 
 /**
- * @brief The ChangeDotClusterBehavior makes Pacman move towards the closest dot cluster
+ * @brief The ChangeDotClusterBehavior makes Pac-Man move towards the closest dot cluster
  * that he is not currently inside of.
  */
 class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {

--- a/demo/include/demo/change_dot_cluster_behavior.hpp
+++ b/demo/include/demo/change_dot_cluster_behavior.hpp
@@ -12,7 +12,7 @@ namespace demo {
  * @brief The ChangeDotClusterBehavior makes Pacman move towards the closest dot cluster
  * that he is not currently inside of.
  */
-class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<Command> {
+class ChangeDotClusterBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<ChangeDotClusterBehavior>;
     using ConstPtr = std::shared_ptr<const ChangeDotClusterBehavior>;
@@ -20,28 +20,25 @@ public:
     using Cluster = utils::Cluster;
     using Clusters = utils::DotClusterFinder::Clusters;
 
-    explicit ChangeDotClusterBehavior(EnvironmentModel::Ptr environmentModel,
-                                      const std::string& name = "ChangeDotCluster")
-            : Behavior(name), environmentModel_{std::move(environmentModel)} {
+    explicit ChangeDotClusterBehavior(const std::string& name = "ChangeDotCluster") : Behavior(name) {
     }
 
-    Command getCommand(const Time& /*time*/) override;
+    Command getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& /*time*/) const override;
-    bool checkCommitmentCondition(const Time& /*time*/) const override;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
 
-    void gainControl(const Time& /*time*/) override {
-        setTargetCluster();
+    void gainControl(const Time& /*time*/, const EnvironmentModel& environmentModel) override {
+        setTargetCluster(environmentModel);
     }
-    void loseControl(const Time& /*time*/) override {
+    void loseControl(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) override {
         targetCluster_.reset();
     }
 
 private:
-    void setTargetCluster();
+    void setTargetCluster(const EnvironmentModel& environmentModel);
 
     std::optional<Cluster> targetCluster_;
-    EnvironmentModel::Ptr environmentModel_;
 };
 
 } // namespace demo

--- a/demo/include/demo/chase_ghost_behavior.hpp
+++ b/demo/include/demo/chase_ghost_behavior.hpp
@@ -13,7 +13,7 @@ namespace demo {
  * The behavior returns the command which decreases the distance between Pacman and the ghost that's currently closest
  * to him. It is applicable once Pacman at a power pill and the ghosts are scared of him.
  */
-class ChaseGhostBehavior : public arbitration_graphs::Behavior<Command> {
+class ChaseGhostBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<ChaseGhostBehavior>;
     using ConstPtr = std::shared_ptr<const ChaseGhostBehavior>;
@@ -25,19 +25,16 @@ public:
         int minScaredTicksLeft{5};
     };
 
-    explicit ChaseGhostBehavior(EnvironmentModel::Ptr environmentModel,
-                                const Parameters& parameters,
-                                const std::string& name = "ChaseGhost")
-            : Behavior(name), environmentModel_{std::move(environmentModel)}, parameters_{parameters} {
+    explicit ChaseGhostBehavior(const Parameters& parameters, const std::string& name = "ChaseGhost")
+            : Behavior(name), parameters_{parameters} {
     }
 
     Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
     bool checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
-    bool checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
 
 private:
-    EnvironmentModel::Ptr environmentModel_;
     Parameters parameters_;
 };
 

--- a/demo/include/demo/chase_ghost_behavior.hpp
+++ b/demo/include/demo/chase_ghost_behavior.hpp
@@ -8,10 +8,10 @@
 namespace demo {
 
 /**
- * @brief The ChaseGhostBehavior makes Pacman run away from the ghost.
+ * @brief The ChaseGhostBehavior makes Pac-Man run away from the ghost.
  *
- * The behavior returns the command which decreases the distance between Pacman and the ghost that's currently closest
- * to him. It is applicable once Pacman at a power pill and the ghosts are scared of him.
+ * The behavior returns the command which decreases the distance between Pac-Man and the ghost that's currently closest
+ * to him. It is applicable once Pac-Man ate a power pill and the ghosts are scared of him.
  */
 class ChaseGhostBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:

--- a/demo/include/demo/chase_ghost_behavior.hpp
+++ b/demo/include/demo/chase_ghost_behavior.hpp
@@ -31,10 +31,10 @@ public:
             : Behavior(name), environmentModel_{std::move(environmentModel)}, parameters_{parameters} {
     }
 
-    Command getCommand(const Time& time) override;
+    Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& time) const override;
-    bool checkCommitmentCondition(const Time& time) const override;
+    bool checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const override;
 
 private:
     EnvironmentModel::Ptr environmentModel_;

--- a/demo/include/demo/cost_estimator.hpp
+++ b/demo/include/demo/cost_estimator.hpp
@@ -11,15 +11,14 @@ namespace demo {
 /**
  * @brief The CostEstimator estimates a cost quantity for a given command to be used as a decision heuristic.
  */
-struct CostEstimator : public arbitration_graphs::CostEstimator<Command> {
+struct CostEstimator : public arbitration_graphs::CostEstimator<EnvironmentModel, Command> {
     struct Parameters {
         /// @brief The radius of the neighborhood around the end of the path that is checked for dots.
         /// A radius of 2 will result in a 5x5 neighborhood.
         int pathEndNeighborhoodRadius{3};
     };
 
-    explicit CostEstimator(EnvironmentModel::Ptr environmentModel, const Parameters& parameters)
-            : environmentModel_{std::move(environmentModel)}, parameters_{parameters} {
+    explicit CostEstimator(const Parameters& parameters) : parameters_{parameters} {
     }
 
     /**
@@ -29,10 +28,12 @@ struct CostEstimator : public arbitration_graphs::CostEstimator<Command> {
      * of the path. This is done to balance the short-term gain by following a path with many dots and the long-term
      * gain by moving towards a promising area.
      */
-    double estimateCost(const Command& command, bool /*isActive*/) override;
+    double estimateCost(const Time& time,
+                        const EnvironmentModel& environmentModel,
+                        const Command& command,
+                        bool /*isActive*/) override;
 
 private:
-    EnvironmentModel::Ptr environmentModel_;
     Parameters parameters_;
 };
 } // namespace demo

--- a/demo/include/demo/eat_closest_dot_behavior.hpp
+++ b/demo/include/demo/eat_closest_dot_behavior.hpp
@@ -10,22 +10,18 @@ namespace demo {
 /**
  * @brief The EatClosestDotBehavior makes pacman move towards the closest dot.
  */
-class EatClosestDotBehavior : public arbitration_graphs::Behavior<Command> {
+class EatClosestDotBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<EatClosestDotBehavior>;
     using ConstPtr = std::shared_ptr<const EatClosestDotBehavior>;
 
-    explicit EatClosestDotBehavior(EnvironmentModel::Ptr environmentModel, const std::string& name = "EatClosestDot")
-            : Behavior(name), environmentModel_{std::move(environmentModel)} {
+    explicit EatClosestDotBehavior(const std::string& name = "EatClosestDot") : Behavior(name) {
     }
 
-    Command getCommand(const Time& /*time*/) override;
+    Command getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& /*time*/) const override;
-    bool checkCommitmentCondition(const Time& /*time*/) const override;
-
-private:
-    EnvironmentModel::Ptr environmentModel_;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
 };
 
 } // namespace demo

--- a/demo/include/demo/eat_closest_dot_behavior.hpp
+++ b/demo/include/demo/eat_closest_dot_behavior.hpp
@@ -8,7 +8,7 @@
 namespace demo {
 
 /**
- * @brief The EatClosestDotBehavior makes pacman move towards the closest dot.
+ * @brief The EatClosestDotBehavior makes Pac-Man move towards the closest dot.
  */
 class EatClosestDotBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
@@ -20,8 +20,8 @@ public:
 
     Command getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
-    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override;
 };
 
 } // namespace demo

--- a/demo/include/demo/environment_model.hpp
+++ b/demo/include/demo/environment_model.hpp
@@ -92,7 +92,7 @@ public:
         return astar_.mazeDistance(start, goal);
     }
 
-    std::optional<Path> pathTo(const Position& goal) {
+    std::optional<Path> pathTo(const Position& goal) const {
         return astar_.shortestPath(pacmanPosition(), goal);
     }
 

--- a/demo/include/demo/move_randomly_behavior.hpp
+++ b/demo/include/demo/move_randomly_behavior.hpp
@@ -27,7 +27,7 @@ public:
             : Behavior{name}, parameters_{parameters} {
     }
 
-    Command getCommand(const Time& time) override;
+    Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
     bool checkInvocationCondition(const Time& /*time*/) const override;
     bool checkCommitmentCondition(const Time& /*time*/) const override;

--- a/demo/include/demo/move_randomly_behavior.hpp
+++ b/demo/include/demo/move_randomly_behavior.hpp
@@ -3,6 +3,7 @@
 #include <arbitration_graphs/behavior.hpp>
 #include <util_caching/cache.hpp>
 
+#include "environment_model.hpp"
 #include "types.hpp"
 
 namespace demo {
@@ -14,7 +15,7 @@ namespace demo {
  * amount of time to avoid changing the direction too frequently.
  *
  */
-class MoveRandomlyBehavior : public arbitration_graphs::Behavior<Command> {
+class MoveRandomlyBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<MoveRandomlyBehavior>;
     using ConstPtr = std::shared_ptr<const MoveRandomlyBehavior>;
@@ -29,8 +30,8 @@ public:
 
     Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& /*time*/) const override;
-    bool checkCommitmentCondition(const Time& /*time*/) const override;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
 
 private:
     Direction selectRandomDirection();

--- a/demo/include/demo/move_randomly_behavior.hpp
+++ b/demo/include/demo/move_randomly_behavior.hpp
@@ -9,7 +9,7 @@
 namespace demo {
 
 /**
- * @brief The MoveRandomly moves Pacman in a random direction.
+ * @brief The MoveRandomly moves Pac-Man in a random direction.
  *
  * This behavior will not consider ghosts or walls. Once a direction is selected, it will be returned for a defined
  * amount of time to avoid changing the direction too frequently.
@@ -28,10 +28,10 @@ public:
             : Behavior{name}, parameters_{parameters} {
     }
 
-    Command getCommand(const Time& time, const EnvironmentModel& environmentModel) override;
+    Command getCommand(const Time& time, const EnvironmentModel& /*environmentModel*/) override;
 
-    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
-    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override;
 
 private:
     Direction selectRandomDirection();

--- a/demo/include/demo/pacman_agent.hpp
+++ b/demo/include/demo/pacman_agent.hpp
@@ -64,8 +64,8 @@ public:
                                        PriorityArbitrator::Option::FALLBACK);
     }
 
-    Command getCommand(const Time& time) {
-        return rootArbitrator_->getCommand(time);
+    Command getCommand(const Time& time, const EnvironmentModel& environmentModel) {
+        return rootArbitrator_->getCommand(time, environmentModel);
     }
 
     void updateEnvironmentModel(const entt::Game& game) {
@@ -76,18 +76,18 @@ public:
         return environmentModel_;
     }
 
-    std::ostream& to_stream(std::ostream& output, const Time& time) const {
+    std::ostream& to_stream(std::ostream& output, const Time& time, const EnvironmentModel& environmentModel) const {
         return rootArbitrator_->to_stream(output, time);
     }
-    std::string to_str(const Time& time) const {
+    std::string to_str(const Time& time, const EnvironmentModel& environmentModel) const {
         std::stringstream stringStream;
         to_stream(stringStream, time);
         return stringStream.str();
     }
-    std::string yamlString(const Time& time) const {
+    std::string yamlString(const Time& time, const EnvironmentModel& environmentModel) const {
         YAML::Node node;
         node["type"] = "PacmanArbitrator";
-        node["arbitration"] = rootArbitrator_->toYaml(time);
+        node["arbitration"] = rootArbitrator_->toYaml(time, environmentModel);
         std::stringstream yamlString;
         yamlString << node;
         return yamlString.str();

--- a/demo/include/demo/pacman_agent.hpp
+++ b/demo/include/demo/pacman_agent.hpp
@@ -37,6 +37,8 @@ public:
     };
 
     explicit PacmanAgent(const entt::Game& game) : environmentModel_{game} {
+        verifier_ = std::make_shared<Verifier>();
+
         avoidGhostBehavior_ = std::make_shared<AvoidGhostBehavior>(parameters_.avoidGhostBehavior);
         changeDotClusterBehavior_ = std::make_shared<ChangeDotClusterBehavior>();
         chaseGhostBehavior_ = std::make_shared<ChaseGhostBehavior>(parameters_.chaseGhostBehavior);

--- a/demo/include/demo/pacman_agent.hpp
+++ b/demo/include/demo/pacman_agent.hpp
@@ -17,11 +17,11 @@
 namespace demo {
 
 /**
- * @brief The main arbitrator class for the Pacman demo.
+ * @brief The main arbitrator class for the Pac-Man demo.
  *
  * The PacmanArbitrator class defines the arbitration graph by adding the individual behaviors.
  * It is the represents the top level of the hierarchy and will be called in each time step to return the command that
- * Pacman should execute.
+ * Pac-Man should execute.
  */
 class PacmanAgent {
 public:
@@ -53,7 +53,7 @@ public:
         eatDotsArbitrator_->addOption(
             eatClosestDotBehavior_, CostArbitrator::Option::Flags::INTERRUPTABLE, costEstimator_);
 
-        rootArbitrator_ = std::make_shared<PriorityArbitrator>("Pacman", verifier_);
+        rootArbitrator_ = std::make_shared<PriorityArbitrator>("Pac-Man", verifier_);
         rootArbitrator_->addOption(chaseGhostBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(avoidGhostBehavior_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);
         rootArbitrator_->addOption(eatDotsArbitrator_, PriorityArbitrator::Option::Flags::INTERRUPTABLE);

--- a/demo/include/demo/stay_in_place_behavior.hpp
+++ b/demo/include/demo/stay_in_place_behavior.hpp
@@ -15,23 +15,20 @@ namespace demo {
  * Due to the fact that Pacman will never stop moving, this means that when this behavior is called, Pacman will keep
  * moving in the same direction as before.
  */
-class StayInPlaceBehavior : public arbitration_graphs::Behavior<Command> {
+class StayInPlaceBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<StayInPlaceBehavior>;
     using ConstPtr = std::shared_ptr<const StayInPlaceBehavior>;
 
-    explicit StayInPlaceBehavior(EnvironmentModel::Ptr environmentModel, const std::string& name = "StayInPlace")
-            : Behavior(name), environmentModel_{std::move(environmentModel)} {
+    explicit StayInPlaceBehavior(const std::string& name = "StayInPlace") : Behavior(name) {
     }
 
-    Command getCommand(const Time& /*time*/) override;
+    Command getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) override;
 
-    bool checkInvocationCondition(const Time& /*time*/) const override;
-    bool checkCommitmentCondition(const Time& /*time*/) const override;
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& environmentModel) const override;
 
 private:
-    EnvironmentModel::Ptr environmentModel_;
-
     static Direction oppositeDirection(const Direction& direction) {
         const std::map<Direction, Direction> oppositeDirectionMap{{Direction::UP, Direction::DOWN},
                                                                   {Direction::DOWN, Direction::UP},

--- a/demo/include/demo/stay_in_place_behavior.hpp
+++ b/demo/include/demo/stay_in_place_behavior.hpp
@@ -8,12 +8,11 @@
 namespace demo {
 
 /**
- * @brief The DoNothingBehavior does just that. Nothing.
+ * @brief The StayInPlaceBehavior does just that. Since Pac-Man cannot stop moving, this behavior will oscillate between
+ * the current direction and the opposite direction.
  *
- * The behavior can be called any time and will always return a command with direction NONE.
- * It is intended to be used as a fallback behavior when no other behavior is available.
- * Due to the fact that Pacman will never stop moving, this means that when this behavior is called, Pacman will keep
- * moving in the same direction as before.
+ * The behavior can be called any time. It is intended to be used as a fallback behavior when no other behavior is
+ * available.
  */
 class StayInPlaceBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:

--- a/demo/include/demo/verifier.hpp
+++ b/demo/include/demo/verifier.hpp
@@ -23,28 +23,23 @@ private:
 };
 
 
-class Verifier : public arbitration_graphs::verification::AbstractVerifier<Command> {
+class Verifier : public arbitration_graphs::verification::AbstractVerifier<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<Verifier>;
     using ConstPtr = std::shared_ptr<const Verifier>;
 
-    explicit Verifier(EnvironmentModel::Ptr environmentModel) : environmentModel_{std::move(environmentModel)} {
-    }
-
     arbitration_graphs::verification::AbstractResult::Ptr analyze(const Time& /*time*/,
+                                                                  const EnvironmentModel& environmentModel,
                                                                   const Command& command) const override {
         Move nextMove = Move{command.path.front()};
-        Position nextPosition = environmentModel_->pacmanPosition() + nextMove.deltaPosition;
+        Position nextPosition = environmentModel.pacmanPosition() + nextMove.deltaPosition;
 
-        if (environmentModel_->isPassableCell(nextPosition)) {
+        if (environmentModel.isPassableCell(nextPosition)) {
             return std::make_shared<VerificationResult>(true);
         }
 
         return std::make_shared<VerificationResult>(false);
     }
-
-private:
-    EnvironmentModel::Ptr environmentModel_;
 };
 } // namespace demo
 

--- a/demo/include/utils/pacman_wrapper.hpp
+++ b/demo/include/utils/pacman_wrapper.hpp
@@ -18,7 +18,7 @@ public:
         SDL_Quit();
     }
 
-    void progressGame(const demo::Command& command, const demo::EnvironmentModel::ConstPtr& environmentModel);
+    void progressGame(const demo::Command& command, const demo::EnvironmentModel& environmentModel);
 
     bool quit() const {
         return quit_;

--- a/demo/include/utils/utils.hpp
+++ b/demo/include/utils/utils.hpp
@@ -5,10 +5,8 @@
 
 namespace utils {
 
-int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel::ConstPtr& environmentModel);
+int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel& environmentModel);
 
-int dotsInRadius(const Position& center,
-                 const demo::EnvironmentModel::ConstPtr& environmentModel,
-                 int pathEndNeighborhoodRadius);
+int dotsInRadius(const Position& center, const demo::EnvironmentModel& environmentModel, int pathEndNeighborhoodRadius);
 
 } // namespace utils

--- a/demo/src/avoid_ghost_behavior.cpp
+++ b/demo/src/avoid_ghost_behavior.cpp
@@ -4,19 +4,19 @@
 namespace demo {
 
 Command AvoidGhostBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
-    auto pacmanPosition = environmentModel_->pacmanPosition();
-    auto ghostPosition = environmentModel_->closestGhost(time).ghost.position;
+    auto pacmanPosition = environmentModel.pacmanPosition();
+    auto ghostPosition = environmentModel.closestGhost(time).ghost.position;
 
     std::optional<Direction> direction;
     double maxDistance = -1;
     for (const auto& move : Move::possibleMoves()) {
-        auto nextPosition = environmentModel_->positionConsideringTunnel(pacmanPosition + move.deltaPosition);
+        auto nextPosition = environmentModel.positionConsideringTunnel(pacmanPosition + move.deltaPosition);
 
-        if (environmentModel_->isWall(nextPosition)) {
+        if (environmentModel.isWall(nextPosition)) {
             continue;
         }
 
-        auto nextDistance = environmentModel_->mazeDistance(nextPosition, ghostPosition);
+        auto nextDistance = environmentModel.mazeDistance(nextPosition, ghostPosition);
         if (nextDistance > maxDistance) {
             direction = move.direction;
             maxDistance = nextDistance;
@@ -31,11 +31,11 @@ Command AvoidGhostBehavior::getCommand(const Time& time, const EnvironmentModel&
 }
 
 bool AvoidGhostBehavior::checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const {
-    return environmentModel_->closestGhost(time).distance < parameters_.invocationMinDistance;
+    return environmentModel.closestGhost(time).distance < parameters_.invocationMinDistance;
 }
 
-bool AvoidGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const {
-    return environmentModel_->closestGhost(time).distance < parameters_.commitmentMinDistance;
+bool AvoidGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModel& environmentModel) const {
+    return environmentModel.closestGhost(time).distance < parameters_.commitmentMinDistance;
 }
 
 } // namespace demo

--- a/demo/src/avoid_ghost_behavior.cpp
+++ b/demo/src/avoid_ghost_behavior.cpp
@@ -3,7 +3,7 @@
 
 namespace demo {
 
-Command AvoidGhostBehavior::getCommand(const Time& time) {
+Command AvoidGhostBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
     auto pacmanPosition = environmentModel_->pacmanPosition();
     auto ghostPosition = environmentModel_->closestGhost(time).ghost.position;
 
@@ -30,11 +30,11 @@ Command AvoidGhostBehavior::getCommand(const Time& time) {
     return Command{direction.value()};
 }
 
-bool AvoidGhostBehavior::checkInvocationCondition(const Time& time) const {
+bool AvoidGhostBehavior::checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const {
     return environmentModel_->closestGhost(time).distance < parameters_.invocationMinDistance;
 }
 
-bool AvoidGhostBehavior::checkCommitmentCondition(const Time& time) const {
+bool AvoidGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const {
     return environmentModel_->closestGhost(time).distance < parameters_.commitmentMinDistance;
 }
 

--- a/demo/src/change_dot_cluster_behavior.cpp
+++ b/demo/src/change_dot_cluster_behavior.cpp
@@ -2,8 +2,8 @@
 
 namespace demo {
 
-Command ChangeDotClusterBehavior::getCommand(const Time& /*time*/) {
-    std::optional<Path> pathToTargetClusterCenter = environmentModel_->pathTo(targetCluster_->center);
+Command ChangeDotClusterBehavior::getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) {
+    std::optional<Path> pathToTargetClusterCenter = environmentModel.pathTo(targetCluster_->center);
 
     if (!pathToTargetClusterCenter) {
         throw std::runtime_error("Failed to compute path to target cluster. Can not provide a sensible command.");
@@ -12,9 +12,10 @@ Command ChangeDotClusterBehavior::getCommand(const Time& /*time*/) {
     return Command{pathToTargetClusterCenter.value()};
 }
 
-bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/) const {
-    auto pacmanPosition = environmentModel_->pacmanPosition();
-    Clusters clusters = environmentModel_->dotCluster();
+bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/,
+                                                        const EnvironmentModel& environmentModel) const {
+    auto pacmanPosition = environmentModel.pacmanPosition();
+    Clusters clusters = environmentModel.dotCluster();
 
     if (clusters.empty()) {
         // We cannot navigate to a cluster if there aren't any
@@ -28,18 +29,19 @@ bool ChangeDotClusterBehavior::checkInvocationCondition(const Time& /*time*/) co
     return true;
 }
 
-bool ChangeDotClusterBehavior::checkCommitmentCondition(const Time& /*time*/) const {
-    Position pacmanPosition = environmentModel_->pacmanPosition();
+bool ChangeDotClusterBehavior::checkCommitmentCondition(const Time& /*time*/,
+                                                        const EnvironmentModel& environmentModel) const {
+    Position pacmanPosition = environmentModel.pacmanPosition();
     return !targetCluster_->isInCluster(pacmanPosition);
 }
 
-void ChangeDotClusterBehavior::setTargetCluster() {
-    auto pacmanPosition = environmentModel_->pacmanPosition();
-    Clusters clusters = environmentModel_->dotCluster();
+void ChangeDotClusterBehavior::setTargetCluster(const EnvironmentModel& environmentModel) {
+    auto pacmanPosition = environmentModel.pacmanPosition();
+    Clusters clusters = environmentModel.dotCluster();
 
     int minDistance = std::numeric_limits<int>::max();
     for (const auto& cluster : clusters) {
-        int distance = environmentModel_->mazeDistance(pacmanPosition, cluster.center);
+        int distance = environmentModel.mazeDistance(pacmanPosition, cluster.center);
         if (distance < minDistance && !cluster.isInCluster(pacmanPosition)) {
             minDistance = distance;
             targetCluster_ = cluster;

--- a/demo/src/chase_ghost_behavior.cpp
+++ b/demo/src/chase_ghost_behavior.cpp
@@ -3,7 +3,7 @@
 
 namespace demo {
 
-Command ChaseGhostBehavior::getCommand(const Time& time) {
+Command ChaseGhostBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
     auto pacmanPosition = environmentModel_->pacmanPosition();
 
     auto closestScaredGhost = environmentModel_->closestScaredGhost(time);
@@ -37,13 +37,13 @@ Command ChaseGhostBehavior::getCommand(const Time& time) {
     return Command{direction.value()};
 }
 
-bool ChaseGhostBehavior::checkInvocationCondition(const Time& time) const {
+bool ChaseGhostBehavior::checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const {
     return environmentModel_->closestScaredGhost(time).has_value() &&
            environmentModel_->closestScaredGhost(time)->ghost.scaredCountdown > parameters_.minScaredTicksLeft &&
            environmentModel_->closestScaredGhost(time)->distance < parameters_.invocationMinDistance;
 }
 
-bool ChaseGhostBehavior::checkCommitmentCondition(const Time& time) const {
+bool ChaseGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const {
     return checkInvocationCondition(time);
 }
 

--- a/demo/src/chase_ghost_behavior.cpp
+++ b/demo/src/chase_ghost_behavior.cpp
@@ -4,9 +4,9 @@
 namespace demo {
 
 Command ChaseGhostBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
-    auto pacmanPosition = environmentModel_->pacmanPosition();
+    auto pacmanPosition = environmentModel.pacmanPosition();
 
-    auto closestScaredGhost = environmentModel_->closestScaredGhost(time);
+    auto closestScaredGhost = environmentModel.closestScaredGhost(time);
     if (!closestScaredGhost) {
         throw std::runtime_error("Can not compute command to chase ghost because there are no scared ghosts.");
     }
@@ -16,14 +16,14 @@ Command ChaseGhostBehavior::getCommand(const Time& time, const EnvironmentModel&
     std::optional<Direction> direction;
     double minDistance = std::numeric_limits<double>::max();
     for (const auto& move : Move::possibleMoves()) {
-        auto nextPosition = environmentModel_->positionConsideringTunnel(pacmanPosition + move.deltaPosition);
+        auto nextPosition = environmentModel.positionConsideringTunnel(pacmanPosition + move.deltaPosition);
 
-        if (environmentModel_->isWall(nextPosition)) {
+        if (environmentModel.isWall(nextPosition)) {
             continue;
         }
 
         // Chose the direction moving pacman towards the closest scared ghost (considering ghost movement)
-        auto nextDistance = environmentModel_->mazeDistance(nextPosition, ghostPosition);
+        auto nextDistance = environmentModel.mazeDistance(nextPosition, ghostPosition);
         if (nextDistance < minDistance) {
             direction = move.direction;
             minDistance = nextDistance;
@@ -38,13 +38,13 @@ Command ChaseGhostBehavior::getCommand(const Time& time, const EnvironmentModel&
 }
 
 bool ChaseGhostBehavior::checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const {
-    return environmentModel_->closestScaredGhost(time).has_value() &&
-           environmentModel_->closestScaredGhost(time)->ghost.scaredCountdown > parameters_.minScaredTicksLeft &&
-           environmentModel_->closestScaredGhost(time)->distance < parameters_.invocationMinDistance;
+    return environmentModel.closestScaredGhost(time).has_value() &&
+           environmentModel.closestScaredGhost(time)->ghost.scaredCountdown > parameters_.minScaredTicksLeft &&
+           environmentModel.closestScaredGhost(time)->distance < parameters_.invocationMinDistance;
 }
 
-bool ChaseGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModelT& environmentModel) const {
-    return checkInvocationCondition(time);
+bool ChaseGhostBehavior::checkCommitmentCondition(const Time& time, const EnvironmentModel& environmentModel) const {
+    return checkInvocationCondition(time, environmentModel);
 }
 
 } // namespace demo

--- a/demo/src/cost_estimator.cpp
+++ b/demo/src/cost_estimator.cpp
@@ -4,12 +4,15 @@
 
 namespace demo {
 
-double CostEstimator::estimateCost(const Command& command, bool /*isActive*/) {
-    Positions absolutePath = environmentModel_->toAbsolutePath(command.path);
+double CostEstimator::estimateCost(const Time& /*time*/,
+                                   const EnvironmentModel& environmentModel,
+                                   const Command& command,
+                                   bool /*isActive*/) {
+    Positions absolutePath = environmentModel.toAbsolutePath(command.path);
 
-    const int nDotsAlongPath = utils::dotsAlongPath(absolutePath, environmentModel_);
+    const int nDotsAlongPath = utils::dotsAlongPath(absolutePath, environmentModel);
     const int nDotsInRadius =
-        utils::dotsInRadius(absolutePath.back(), environmentModel_, parameters_.pathEndNeighborhoodRadius);
+        utils::dotsInRadius(absolutePath.back(), environmentModel, parameters_.pathEndNeighborhoodRadius);
     const int nDots = nDotsAlongPath + nDotsInRadius;
 
     if (nDots == 0) {

--- a/demo/src/eat_closest_dot_behavior.cpp
+++ b/demo/src/eat_closest_dot_behavior.cpp
@@ -2,9 +2,9 @@
 
 namespace demo {
 
-Command EatClosestDotBehavior::getCommand(const Time& /*time*/) {
-    auto pacmanPosition = environmentModel_->pacmanPosition();
-    std::optional<Path> pathToClosestDot = environmentModel_->pathToClosestDot(pacmanPosition);
+Command EatClosestDotBehavior::getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) {
+    auto pacmanPosition = environmentModel.pacmanPosition();
+    std::optional<Path> pathToClosestDot = environmentModel.pathToClosestDot(pacmanPosition);
 
     if (!pathToClosestDot) {
         throw std::runtime_error("Failed to compute path to closest dot. Can not provide a sensible command.");
@@ -13,14 +13,16 @@ Command EatClosestDotBehavior::getCommand(const Time& /*time*/) {
     return Command{pathToClosestDot.value()};
 }
 
-bool EatClosestDotBehavior::checkInvocationCondition(const Time& /*time*/) const {
+bool EatClosestDotBehavior::checkInvocationCondition(const Time& /*time*/,
+                                                     const EnvironmentModel& /*environmentModel*/) const {
     // This behavior is only applicable if there is at least one dot. We should check for the presence of a dot
     // here, but since the game is won when all dots are collected, we assume at least one dot exists when this
     // behavior is invoked.
     return true;
 }
 
-bool EatClosestDotBehavior::checkCommitmentCondition(const Time& /*time*/) const {
+bool EatClosestDotBehavior::checkCommitmentCondition(const Time& /*time*/,
+                                                     const EnvironmentModel& /*environmentModel*/) const {
     return false;
 }
 

--- a/demo/src/main.cpp
+++ b/demo/src/main.cpp
@@ -26,7 +26,7 @@ int main() {
 
             const Time time = Clock::now();
 
-            Command command = agent.getCommand(time);
+            Command command = agent.getCommand(time, environmentModel);
 
             server.broadcast(agent.yamlString(time));
 

--- a/demo/src/main.cpp
+++ b/demo/src/main.cpp
@@ -26,7 +26,7 @@ int main() {
 
             const Time time = Clock::now();
 
-            Command command = agent.getCommand(time, environmentModel);
+            Command command = agent.getCommand(time);
 
             server.broadcast(agent.yamlString(time));
 

--- a/demo/src/move_randomly_behavior.cpp
+++ b/demo/src/move_randomly_behavior.cpp
@@ -15,13 +15,6 @@ Command MoveRandomlyBehavior::getCommand(const Time& time, const EnvironmentMode
     return Command{randomDirection};
 }
 
-Direction MoveRandomlyBehavior::selectRandomDirection() {
-    int randomIndex = discreteRandomDistribution_(randomGenerator_);
-    Move randomMove = Move::possibleMoves().at(randomIndex);
-
-    return randomMove.direction;
-}
-
 bool MoveRandomlyBehavior::checkInvocationCondition(const Time& /*time*/,
                                                     const EnvironmentModel& /*environmentModel*/) const {
     return true;
@@ -29,6 +22,13 @@ bool MoveRandomlyBehavior::checkInvocationCondition(const Time& /*time*/,
 bool MoveRandomlyBehavior::checkCommitmentCondition(const Time& /*time*/,
                                                     const EnvironmentModel& /*environmentModel*/) const {
     return false;
+}
+
+Direction MoveRandomlyBehavior::selectRandomDirection() {
+    int randomIndex = discreteRandomDistribution_(randomGenerator_);
+    Move randomMove = Move::possibleMoves().at(randomIndex);
+
+    return randomMove.direction;
 }
 
 } // namespace demo

--- a/demo/src/move_randomly_behavior.cpp
+++ b/demo/src/move_randomly_behavior.cpp
@@ -2,7 +2,7 @@
 
 namespace demo {
 
-Command MoveRandomlyBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
+Command MoveRandomlyBehavior::getCommand(const Time& time, const EnvironmentModel& /*environmentModel*/) {
     util_caching::policies::ApproximateTime<Time, std::chrono::seconds> approximateTimePolicy{
         parameters_.selectionFixedFor.count()};
     if (directionCache_.cached(time, approximateTimePolicy)) {
@@ -22,10 +22,12 @@ Direction MoveRandomlyBehavior::selectRandomDirection() {
     return randomMove.direction;
 }
 
-bool MoveRandomlyBehavior::checkInvocationCondition(const Time& /*time*/) const {
+bool MoveRandomlyBehavior::checkInvocationCondition(const Time& /*time*/,
+                                                    const EnvironmentModel& /*environmentModel*/) const {
     return true;
 }
-bool MoveRandomlyBehavior::checkCommitmentCondition(const Time& /*time*/) const {
+bool MoveRandomlyBehavior::checkCommitmentCondition(const Time& /*time*/,
+                                                    const EnvironmentModel& /*environmentModel*/) const {
     return false;
 }
 

--- a/demo/src/move_randomly_behavior.cpp
+++ b/demo/src/move_randomly_behavior.cpp
@@ -2,7 +2,7 @@
 
 namespace demo {
 
-Command MoveRandomlyBehavior::getCommand(const Time& time) {
+Command MoveRandomlyBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
     util_caching::policies::ApproximateTime<Time, std::chrono::seconds> approximateTimePolicy{
         parameters_.selectionFixedFor.count()};
     if (directionCache_.cached(time, approximateTimePolicy)) {

--- a/demo/src/pacman_wrapper.cpp
+++ b/demo/src/pacman_wrapper.cpp
@@ -88,8 +88,7 @@ void PacmanWrapper::handleUserInput() {
     }
 }
 
-void PacmanWrapper::progressGame(const demo::Command& command,
-                                 const demo::EnvironmentModel::ConstPtr& environmentModel) {
+void PacmanWrapper::progressGame(const demo::Command& command, const demo::EnvironmentModel& environmentModel) {
     handleUserInput();
 
     game_.input(command.scancode());
@@ -110,7 +109,7 @@ void PacmanWrapper::progressGame(const demo::Command& command,
     game_.render(writer_, frame_ % tileSize);
 
     if (renderPath_) {
-        renderPath(environmentModel->toAbsolutePath(command.path));
+        renderPath(environmentModel.toAbsolutePath(command.path));
     }
 
     frame_++;

--- a/demo/src/stay_in_place_behavior.cpp
+++ b/demo/src/stay_in_place_behavior.cpp
@@ -2,15 +2,17 @@
 
 namespace demo {
 
-Command StayInPlaceBehavior::getCommand(const Time& /*time*/) {
-    Direction currentDirection = environmentModel_->pacmanDirection();
+Command StayInPlaceBehavior::getCommand(const Time& /*time*/, const EnvironmentModel& environmentModel) {
+    Direction currentDirection = environmentModel.pacmanDirection();
     return Command{oppositeDirection(currentDirection)};
 }
 
-bool StayInPlaceBehavior::checkInvocationCondition(const Time& /*time*/) const {
+bool StayInPlaceBehavior::checkInvocationCondition(const Time& /*time*/,
+                                                   const EnvironmentModel& /*environmentModel*/) const {
     return true;
 }
-bool StayInPlaceBehavior::checkCommitmentCondition(const Time& /*time*/) const {
+bool StayInPlaceBehavior::checkCommitmentCondition(const Time& /*time*/,
+                                                   const EnvironmentModel& /*environmentModel*/) const {
     return false;
 }
 

--- a/demo/src/utils.cpp
+++ b/demo/src/utils.cpp
@@ -2,11 +2,11 @@
 
 namespace utils {
 
-int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel::ConstPtr& environmentModel) {
+int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel& environmentModel) {
     int nDots{0};
 
     for (const auto& position : absolutePath) {
-        if (environmentModel->isDot(position)) {
+        if (environmentModel.isDot(position)) {
             nDots++;
         }
     }
@@ -14,7 +14,7 @@ int dotsAlongPath(const Positions& absolutePath, const demo::EnvironmentModel::C
 }
 
 int dotsInRadius(const Position& center,
-                 const demo::EnvironmentModel::ConstPtr& environmentModel,
+                 const demo::EnvironmentModel& environmentModel,
                  int pathEndNeighborhoodRadius) {
     int nDots{0};
 
@@ -22,7 +22,7 @@ int dotsInRadius(const Position& center,
     for (int dx = -radius; dx <= radius; ++dx) {
         for (int dy = -radius; dy <= radius; ++dy) {
             Position neighbor = {center.x + dx, center.y + dy};
-            if (environmentModel->isInBounds(neighbor) && environmentModel->isDot(neighbor)) {
+            if (environmentModel.isInBounds(neighbor) && environmentModel.isDot(neighbor)) {
                 nDots++;
             }
         }

--- a/demo/test/astar.cpp
+++ b/demo/test/astar.cpp
@@ -12,14 +12,11 @@ using namespace demo;
 
 class AStarTest : public ::testing::Test {
 protected:
-    AStarTest() : environmentModel_(std::make_shared<MockEnvironmentModel>()) {
-    }
-
-    MockEnvironmentModel::Ptr environmentModel_;
+    MockEnvironmentModel environmentModel_{};
 };
 
 TEST_F(AStarTest, simpleDistance) {
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
 
     EXPECT_EQ(astar.mazeDistance({1, 1}, {1, 1}), 0);
     EXPECT_EQ(astar.mazeDistance({1, 1}, {2, 2}), 2);
@@ -32,9 +29,9 @@ TEST_F(AStarTest, distanceWithWalls) {
                         "# # #"
                         "#   #"
                         "#####"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     EXPECT_EQ(astar.mazeDistance({1, 1}, {3, 3}), 4);
     EXPECT_EQ(astar.mazeDistance({1, 2}, {3, 2}), 4);
 }
@@ -45,9 +42,9 @@ TEST_F(AStarTest, distanceWithHorizontalTunnel) {
                         "     "
                         "#   #"
                         "#####"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     EXPECT_EQ(astar.mazeDistance({0, 2}, {4, 2}), 1);
     EXPECT_EQ(astar.mazeDistance({4, 2}, {0, 2}), 1);
     EXPECT_EQ(astar.mazeDistance({1, 1}, {3, 3}), 4);
@@ -60,9 +57,9 @@ TEST_F(AStarTest, distanceWithVerticalTunnel) {
                         "#   #"
                         "#   #"
                         "## ##"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     EXPECT_EQ(astar.mazeDistance({2, 0}, {2, 4}), 1);
     EXPECT_EQ(astar.mazeDistance({2, 4}, {2, 0}), 1);
     EXPECT_EQ(astar.mazeDistance({1, 1}, {3, 3}), 4);
@@ -70,7 +67,7 @@ TEST_F(AStarTest, distanceWithVerticalTunnel) {
 }
 
 TEST_F(AStarTest, cachedDistance) {
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
 
     // In the first run, we need to compute distance the hard way
     std::clock_t startWithoutCaching = std::clock();
@@ -92,9 +89,9 @@ TEST_F(AStarTest, path) {
                         "# ###"
                         "#   #"
                         "#####"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     std::optional<Path> path = astar.shortestPath({2, 1}, {3, 3});
     Path targetPath = {Direction::LEFT, Direction::DOWN, Direction::DOWN, Direction::RIGHT, Direction::RIGHT};
     ASSERT_TRUE(path.has_value());
@@ -110,9 +107,9 @@ TEST_F(AStarTest, pathWithTunnel) {
                         "     "
                         "#   #"
                         "#####"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     std::optional<Path> path = astar.shortestPath({0, 2}, {4, 2});
     ASSERT_TRUE(path.has_value());
     ASSERT_EQ(path->size(), 1);
@@ -131,9 +128,9 @@ TEST_F(AStarTest, pathToClosestDot) {
                         "#   #"
                         "#  .#"
                         "#####"};
-    environmentModel_->setMaze({5, 6}, str);
+    environmentModel_.setMaze({5, 6}, str);
 
-    AStar astar(environmentModel_->maze());
+    AStar astar(environmentModel_.maze());
     std::optional<Path> path = astar.pathToClosestDot({1, 2});
     ASSERT_TRUE(path.has_value());
 

--- a/demo/test/avoid_ghost_behavior.cpp
+++ b/demo/test/avoid_ghost_behavior.cpp
@@ -63,7 +63,7 @@ TEST_F(AvoidGhostBehaviorTest, getCommandLeft) {
     environmentModel_->setGhostPositions({2, 1});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 }
 
@@ -77,7 +77,7 @@ TEST_F(AvoidGhostBehaviorTest, getCommandRight) {
     environmentModel_->setGhostPositions({0, 1});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 
@@ -91,7 +91,7 @@ TEST_F(AvoidGhostBehaviorTest, getCommandDown) {
     environmentModel_->setGhostPositions({1, 0});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 }
 
@@ -105,7 +105,7 @@ TEST_F(AvoidGhostBehaviorTest, getCommandUp) {
     environmentModel_->setGhostPositions({1, 2});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 
@@ -120,7 +120,7 @@ TEST_F(AvoidGhostBehaviorTest, getCommandAwayFromWall) {
 
     // Even though there is a ghost, pacman should not move towards a wall.
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 

--- a/demo/test/avoid_ghost_behavior.cpp
+++ b/demo/test/avoid_ghost_behavior.cpp
@@ -10,60 +10,58 @@ namespace demo {
 
 class AvoidGhostBehaviorTest : public ::testing::Test {
 protected:
-    AvoidGhostBehaviorTest()
-            : parameters_{}, environmentModel_(std::make_shared<MockEnvironmentModel>()),
-              avoidGhostBehavior_{environmentModel_, parameters_} {
+    AvoidGhostBehaviorTest() : avoidGhostBehavior_{parameters_} {
     }
 
     AvoidGhostBehavior::Parameters parameters_;
-    MockEnvironmentModel::Ptr environmentModel_;
+    MockEnvironmentModel environmentModel_{};
 
     AvoidGhostBehavior avoidGhostBehavior_;
 };
 
 TEST_F(AvoidGhostBehaviorTest, checkInvocationConditionTrue) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 3});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 3});
 
     Time time = Clock::now();
-    ASSERT_TRUE(avoidGhostBehavior_.checkInvocationCondition(time));
+    ASSERT_TRUE(avoidGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(AvoidGhostBehaviorTest, checkInvocationConditionFalse) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({8, 8});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({8, 8});
 
     Time time = Clock::now();
-    ASSERT_FALSE(avoidGhostBehavior_.checkInvocationCondition(time));
+    ASSERT_FALSE(avoidGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(AvoidGhostBehaviorTest, checkCommitmentConditionTrue) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 3});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 3});
 
     Time time = Clock::now();
-    ASSERT_TRUE(avoidGhostBehavior_.checkCommitmentCondition(time));
+    ASSERT_TRUE(avoidGhostBehavior_.checkCommitmentCondition(time, environmentModel_));
 }
 
 TEST_F(AvoidGhostBehaviorTest, checkCommitmentConditionFalse) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({8, 8});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({8, 8});
 
     Time time = Clock::now();
-    ASSERT_FALSE(avoidGhostBehavior_.checkCommitmentCondition(time));
+    ASSERT_FALSE(avoidGhostBehavior_.checkCommitmentCondition(time, environmentModel_));
 }
 
 TEST_F(AvoidGhostBehaviorTest, getCommandLeft) {
     const char str[] = {"###"
                         "   "
                         "###"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 1});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 1});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 }
 
@@ -71,13 +69,13 @@ TEST_F(AvoidGhostBehaviorTest, getCommandRight) {
     const char str[] = {"###"
                         "   "
                         "###"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({0, 1});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({0, 1});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 
@@ -85,13 +83,13 @@ TEST_F(AvoidGhostBehaviorTest, getCommandDown) {
     const char str[] = {"# #"
                         "# #"
                         "# #"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({1, 0});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({1, 0});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 }
 
@@ -99,13 +97,13 @@ TEST_F(AvoidGhostBehaviorTest, getCommandUp) {
     const char str[] = {"# #"
                         "# #"
                         "# #"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({1, 2});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({1, 2});
 
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 
@@ -113,14 +111,14 @@ TEST_F(AvoidGhostBehaviorTest, getCommandAwayFromWall) {
     const char str[] = {"###"
                         "#  "
                         "###"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 1});
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 1});
 
     // Even though there is a ghost, pacman should not move towards a wall.
     Time time = Clock::now();
-    Command command = avoidGhostBehavior_.getCommand(time, environmentModel);
+    Command command = avoidGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 

--- a/demo/test/change_dot_cluster_behavior.cpp
+++ b/demo/test/change_dot_cluster_behavior.cpp
@@ -10,11 +10,9 @@ namespace demo {
 
 class ChangeDotClusterBehaviorTest : public ::testing::Test {
 protected:
-    ChangeDotClusterBehaviorTest()
-            : environmentModel_(std::make_shared<MockEnvironmentModel>()),
-              changeDotClusterBehavior_{environmentModel_} {
+    ChangeDotClusterBehaviorTest() {
         setMazeWithTwoClusters();
-        environmentModel_->setGhostPositions({1, 1});
+        environmentModel_.setGhostPositions({1, 1});
     }
 
     void setMazeWithoutClusters() {
@@ -24,7 +22,7 @@ protected:
                             "#   #"
                             "#   #"
                             "#####"};
-        environmentModel_->setMaze({5, 6}, str);
+        environmentModel_.setMaze({5, 6}, str);
     }
     void setMazeWithOneCluster() {
         const char str[] = {"#####"
@@ -33,7 +31,7 @@ protected:
                             "#   #"
                             "#   #"
                             "#####"};
-        environmentModel_->setMaze({5, 6}, str);
+        environmentModel_.setMaze({5, 6}, str);
     }
     void setMazeWithTwoClusters() {
         const char str[] = {"#####"
@@ -42,12 +40,12 @@ protected:
                             "#   #"
                             "#.. #"
                             "#####"};
-        environmentModel_->setMaze({5, 6}, str);
+        environmentModel_.setMaze({5, 6}, str);
     }
 
-    MockEnvironmentModel::Ptr environmentModel_;
+    MockEnvironmentModel environmentModel_{};
 
-    ChangeDotClusterBehavior changeDotClusterBehavior_;
+    ChangeDotClusterBehavior changeDotClusterBehavior_{};
 };
 
 TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionTrue) {
@@ -57,18 +55,18 @@ TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionTrue) {
 
     // ...we are outside the only cluster that's left
     setMazeWithOneCluster();
-    environmentModel_->setPacmanPosition({1, 3});
+    environmentModel_.setPacmanPosition({1, 3});
 
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // ...or there are multiple clusters left. Doesn't matter if we are outside...
     setMazeWithTwoClusters();
-    environmentModel_->setPacmanPosition({1, 3});
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    environmentModel_.setPacmanPosition({1, 3});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // .. or inside a cluster in that case
-    environmentModel_->setPacmanPosition({1, 1});
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    environmentModel_.setPacmanPosition({1, 1});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionFalse) {
@@ -78,54 +76,54 @@ TEST_F(ChangeDotClusterBehaviorTest, checkInvocationConditionFalse) {
 
     // ..there are no clusters left
     setMazeWithoutClusters();
-    environmentModel_->setPacmanPosition({1, 3});
+    environmentModel_.setPacmanPosition({1, 3});
 
-    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // ...we are inside the only cluster that's left
     setMazeWithOneCluster();
-    environmentModel_->setPacmanPosition({1, 1});
+    environmentModel_.setPacmanPosition({1, 1});
 
-    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    ASSERT_FALSE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(ChangeDotClusterBehaviorTest, checkCommitmentConditionTrue) {
     Time time = Clock::now();
     setMazeWithTwoClusters();
-    environmentModel_->setPacmanPosition({1, 2});
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    environmentModel_.setPacmanPosition({1, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // Once we gained control, we commit to reaching the target dot cluster
-    changeDotClusterBehavior_.gainControl(time);
-    ASSERT_TRUE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+    changeDotClusterBehavior_.gainControl(time, environmentModel_);
+    ASSERT_TRUE(changeDotClusterBehavior_.checkCommitmentCondition(time, environmentModel_));
 }
 
 TEST_F(ChangeDotClusterBehaviorTest, checkCommitmentConditionFalse) {
     Time time = Clock::now();
     setMazeWithTwoClusters();
-    environmentModel_->setPacmanPosition({1, 2});
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
-    changeDotClusterBehavior_.gainControl(time);
+    environmentModel_.setPacmanPosition({1, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
+    changeDotClusterBehavior_.gainControl(time, environmentModel_);
 
     // Once we reached the target cluster, we finished our intended behavior and give up the commitment
-    environmentModel_->setPacmanPosition({2, 1});
-    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+    environmentModel_.setPacmanPosition({2, 1});
+    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time, environmentModel_));
 
     // We reached our goal no matter if we reached the cluster center or just any of the cluster dots
-    environmentModel_->setPacmanPosition({1, 1});
-    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time));
+    environmentModel_.setPacmanPosition({1, 1});
+    ASSERT_FALSE(changeDotClusterBehavior_.checkCommitmentCondition(time, environmentModel_));
 }
 
 TEST_F(ChangeDotClusterBehaviorTest, getCommand) {
     Time time = Clock::now();
     setMazeWithTwoClusters();
-    environmentModel_->setPacmanPosition({2, 2});
-    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time));
+    environmentModel_.setPacmanPosition({2, 2});
+    ASSERT_TRUE(changeDotClusterBehavior_.checkInvocationCondition(time, environmentModel_));
 
-    changeDotClusterBehavior_.gainControl(time);
+    changeDotClusterBehavior_.gainControl(time, environmentModel_);
 
     // The resulting command should navigate us towards the closest cluster center
-    Command command = changeDotClusterBehavior_.getCommand(time, environmentModel);
+    Command command = changeDotClusterBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/change_dot_cluster_behavior.cpp
+++ b/demo/test/change_dot_cluster_behavior.cpp
@@ -125,7 +125,7 @@ TEST_F(ChangeDotClusterBehaviorTest, getCommand) {
     changeDotClusterBehavior_.gainControl(time);
 
     // The resulting command should navigate us towards the closest cluster center
-    Command command = changeDotClusterBehavior_.getCommand(time);
+    Command command = changeDotClusterBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/chase_ghost_behavior.cpp
+++ b/demo/test/chase_ghost_behavior.cpp
@@ -1,7 +1,5 @@
 #include "demo/chase_ghost_behavior.hpp"
 
-#include <memory>
-
 #include <gtest/gtest.h>
 
 #include "mock_environment_model.hpp"
@@ -10,88 +8,86 @@ namespace demo {
 
 class ChaseGhostBehaviorTest : public ::testing::Test {
 protected:
-    ChaseGhostBehaviorTest()
-            : parameters_{}, environmentModel_(std::make_shared<MockEnvironmentModel>()),
-              chaseGhostBehavior_{environmentModel_, parameters_} {
+    ChaseGhostBehaviorTest() : chaseGhostBehavior_{parameters_} {
     }
 
     ChaseGhostBehavior::Parameters parameters_{};
-    MockEnvironmentModel::Ptr environmentModel_;
+    MockEnvironmentModel environmentModel_{};
 
     ChaseGhostBehavior chaseGhostBehavior_;
 };
 
 TEST_F(ChaseGhostBehaviorTest, checkInvocationConditionTrue) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 2});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 2});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    ASSERT_TRUE(chaseGhostBehavior_.checkInvocationCondition(time));
+    ASSERT_TRUE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(ChaseGhostBehaviorTest, checkInvocationConditionFalse) {
-    environmentModel_->setGhostMode(GhostMode::CHASING);
+    environmentModel_.setGhostMode(GhostMode::CHASING);
 
     Time time = Clock::now();
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // We don't want to chase ghosts when they are far away
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({8, 8});
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({8, 8});
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // We don't want to chase ghosts when they are about to chase us again
-    environmentModel_->setScaredCountdown(2);
-    environmentModel_->setGhostPositions({2, 2});
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    environmentModel_.setScaredCountdown(2);
+    environmentModel_.setGhostPositions({2, 2});
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(ChaseGhostBehaviorTest, checkCommitmentConditionTrue) {
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 2});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 2});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    ASSERT_TRUE(chaseGhostBehavior_.checkCommitmentCondition(time));
+    ASSERT_TRUE(chaseGhostBehavior_.checkCommitmentCondition(time, environmentModel_));
 }
 
 TEST_F(ChaseGhostBehaviorTest, checkCommitmentConditionFalse) {
-    environmentModel_->setGhostMode(GhostMode::CHASING);
+    environmentModel_.setGhostMode(GhostMode::CHASING);
 
     Time time = Clock::now();
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // We don't want to chase ghosts when they are far away
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({8, 8});
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({8, 8});
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 
     // We don't want to chase ghosts when they are about to chase us again
-    environmentModel_->setScaredCountdown(2);
-    environmentModel_->setGhostPositions({2, 2});
-    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time));
+    environmentModel_.setScaredCountdown(2);
+    environmentModel_.setGhostPositions({2, 2});
+    ASSERT_FALSE(chaseGhostBehavior_.checkInvocationCondition(time, environmentModel_));
 }
 
 TEST_F(ChaseGhostBehaviorTest, getCommandLeft) {
     const char str[] = {"###"
                         "   "
                         "###"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({0, 1});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({0, 1});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 }
 
@@ -99,15 +95,15 @@ TEST_F(ChaseGhostBehaviorTest, getCommandRight) {
     const char str[] = {"###"
                         "   "
                         "###"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({2, 1});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({2, 1});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 
@@ -115,15 +111,15 @@ TEST_F(ChaseGhostBehaviorTest, getCommandDown) {
     const char str[] = {"# #"
                         "# #"
                         "# #"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({1, 2});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({1, 2});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 }
 
@@ -131,15 +127,15 @@ TEST_F(ChaseGhostBehaviorTest, getCommandUp) {
     const char str[] = {"# #"
                         "# #"
                         "# #"};
-    environmentModel_->setMaze({3, 3}, str);
+    environmentModel_.setMaze({3, 3}, str);
 
-    environmentModel_->setPacmanPosition({1, 1});
-    environmentModel_->setGhostPositions({1, 0});
-    environmentModel_->setGhostMode(GhostMode::SCARED);
-    environmentModel_->setScaredCountdown(40);
+    environmentModel_.setPacmanPosition({1, 1});
+    environmentModel_.setGhostPositions({1, 0});
+    environmentModel_.setGhostMode(GhostMode::SCARED);
+    environmentModel_.setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/chase_ghost_behavior.cpp
+++ b/demo/test/chase_ghost_behavior.cpp
@@ -91,7 +91,7 @@ TEST_F(ChaseGhostBehaviorTest, getCommandLeft) {
     environmentModel_->setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 }
 
@@ -107,7 +107,7 @@ TEST_F(ChaseGhostBehaviorTest, getCommandRight) {
     environmentModel_->setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 }
 
@@ -123,7 +123,7 @@ TEST_F(ChaseGhostBehaviorTest, getCommandDown) {
     environmentModel_->setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 }
 
@@ -139,7 +139,7 @@ TEST_F(ChaseGhostBehaviorTest, getCommandUp) {
     environmentModel_->setScaredCountdown(40);
 
     Time time = Clock::now();
-    Command command = chaseGhostBehavior_.getCommand(time);
+    Command command = chaseGhostBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/cluster.cpp
+++ b/demo/test/cluster.cpp
@@ -24,10 +24,7 @@ bool clusterExists(const std::vector<Cluster>& clusters, const ExpectedCluster& 
 
 class ClusterTest : public ::testing::Test {
 protected:
-    ClusterTest() : environmentModel_(std::make_shared<MockEnvironmentModel>()) {
-    }
-
-    MockEnvironmentModel::Ptr environmentModel_;
+    MockEnvironmentModel environmentModel_;
 };
 
 TEST_F(ClusterTest, dotClusters) {
@@ -36,9 +33,9 @@ TEST_F(ClusterTest, dotClusters) {
                         "     "
                         "#.. #"
                         "#####"};
-    environmentModel_->setMaze({5, 5}, str);
+    environmentModel_.setMaze({5, 5}, str);
 
-    DotClusterFinder dotClusterFinder(environmentModel_->maze());
+    DotClusterFinder dotClusterFinder(environmentModel_.maze());
     std::vector<Cluster> clusters = dotClusterFinder.clusters();
     ASSERT_EQ(clusters.size(), 2);
 

--- a/demo/test/cost_estimator.cpp
+++ b/demo/test/cost_estimator.cpp
@@ -8,11 +8,9 @@ namespace demo {
 
 class CostEstimatorTest : public ::testing::Test {
 protected:
-    CostEstimatorTest()
-            : environmentModel_(std::make_shared<MockEnvironmentModel>()),
-              costEstimator_{environmentModel_, parameters_} {
+    CostEstimatorTest() : costEstimator_{parameters_} {
         setMaze();
-        environmentModel_->setGhostPositions({1, 1});
+        environmentModel_.setGhostPositions({1, 1});
     }
 
     void setMaze() {
@@ -26,10 +24,12 @@ protected:
                             "#...     #"
                             "#...     #"
                             "##########"};
-        environmentModel_->setMaze({10, 10}, str);
+        environmentModel_.setMaze({10, 10}, str);
     }
 
-    MockEnvironmentModel::Ptr environmentModel_;
+    Time time_ = Clock::now();
+
+    MockEnvironmentModel environmentModel_{};
     CostEstimator::Parameters parameters_{1};
 
     CostEstimator costEstimator_;
@@ -37,7 +37,7 @@ protected:
 
 TEST_F(CostEstimatorTest, estimateCostDownPath) {
     // Move from the top left to the bottom left corner
-    environmentModel_->setPacmanPosition({1, 1});
+    environmentModel_.setPacmanPosition({1, 1});
     using D = Direction;
     Path path{D::DOWN, D::DOWN, D::DOWN, D::DOWN, D::DOWN, D::DOWN, D::DOWN};
 
@@ -48,14 +48,14 @@ TEST_F(CostEstimatorTest, estimateCostDownPath) {
     int numOfDots = 4 + 4;
 
     double expectedCost = static_cast<double>(numOfCells) / numOfDots;
-    double actualCost = costEstimator_.estimateCost(Command{path}, true);
+    double actualCost = costEstimator_.estimateCost(time_, environmentModel_, Command{path}, true);
 
     EXPECT_EQ(expectedCost, actualCost);
 }
 
 TEST_F(CostEstimatorTest, estimateCostUpPath) {
     // Move from the bottom left to the top left corner
-    environmentModel_->setPacmanPosition({1, 8});
+    environmentModel_.setPacmanPosition({1, 8});
     using D = Direction;
     Path path{D::UP, D::UP, D::UP, D::UP, D::UP, D::UP, D::UP};
 
@@ -67,20 +67,20 @@ TEST_F(CostEstimatorTest, estimateCostUpPath) {
     int numOfDots = 3 + 0;
 
     double expectedCost = static_cast<double>(numOfCells) / numOfDots;
-    double actualCost = costEstimator_.estimateCost(Command{path}, true);
+    double actualCost = costEstimator_.estimateCost(time_, environmentModel_, Command{path}, true);
 
     EXPECT_EQ(expectedCost, actualCost);
 }
 
 TEST_F(CostEstimatorTest, estimateCostNoDots) {
     // Move from the top left to the top right corner
-    environmentModel_->setPacmanPosition({1, 1});
+    environmentModel_.setPacmanPosition({1, 1});
     using D = Direction;
     Path path{D::RIGHT, D::RIGHT, D::RIGHT, D::RIGHT, D::RIGHT, D::RIGHT, D::RIGHT};
 
     // There are neither points along the path nor in the neighborhood search area
     double expectedCost = std::numeric_limits<double>::max();
-    double actualCost = costEstimator_.estimateCost(Command{path}, true);
+    double actualCost = costEstimator_.estimateCost(time_, environmentModel_, Command{path}, true);
 
     EXPECT_EQ(expectedCost, actualCost);
 }

--- a/demo/test/dummy_behavior.hpp
+++ b/demo/test/dummy_behavior.hpp
@@ -2,6 +2,7 @@
 
 #include <arbitration_graphs/behavior.hpp>
 
+#include "demo/environment_model.hpp"
 #include "demo/types.hpp"
 
 
@@ -16,7 +17,7 @@ const std::string commitmentTrueString = "\033[32mCOMMITMENT\033[39m ";
 const std::string commitmentFalseString = "\033[31mCommitment\033[39m ";
 
 
-class DummyBehavior : public arbitration_graphs::Behavior<Command> {
+class DummyBehavior : public arbitration_graphs::Behavior<EnvironmentModel, Command> {
 public:
     using Ptr = std::shared_ptr<DummyBehavior>;
 
@@ -26,14 +27,14 @@ public:
                   const std::string& name = "DummyBehavior")
             : Behavior(name), invocationCondition_{invocation}, commitmentCondition_{commitment}, command_{command} {};
 
-    Command getCommand(const Time& /*time*/) override {
+    Command getCommand(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) override {
         return command_;
     }
 
-    bool checkInvocationCondition(const Time& /*time*/) const override {
+    bool checkInvocationCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override {
         return invocationCondition_;
     }
-    bool checkCommitmentCondition(const Time& /*time*/) const override {
+    bool checkCommitmentCondition(const Time& /*time*/, const EnvironmentModel& /*environmentModel*/) const override {
         return commitmentCondition_;
     }
 

--- a/demo/test/mock_environment_model.hpp
+++ b/demo/test/mock_environment_model.hpp
@@ -6,12 +6,19 @@
 
 namespace demo {
 
+inline entt::Game makeDummyGame() {
+    entt::Game game;
+    game.init();
+    return game;
+}
+
 class MockEnvironmentModel : public EnvironmentModel {
 public:
     using Ptr = std::shared_ptr<MockEnvironmentModel>;
     using ConstPtr = std::shared_ptr<const MockEnvironmentModel>;
 
-    MockEnvironmentModel() : EnvironmentModel(dummyGame_) {
+    explicit MockEnvironmentModel(entt::Game game = makeDummyGame())
+            : EnvironmentModel(game), dummyGame_{std::move(game)} {
         initializeEntitiesInOppositeCorners();
         setEmptyMaze();
     }

--- a/demo/test/move_randomly_behavior.cpp
+++ b/demo/test/move_randomly_behavior.cpp
@@ -19,10 +19,10 @@ TEST(MoveRandomlyTest, getCachedCommand) {
     MoveRandomlyBehavior moveRandomlyBehavior(MoveRandomlyBehavior::Parameters{selectionValidFor});
 
     Time time = Clock::now();
-    Command firstCommand = moveRandomlyBehavior.getCommand(time);
+    Command firstCommand = moveRandomlyBehavior.getCommand(time, environmentModel);
 
     time += 0.5 * selectionValidFor;
-    Command secondCommand = moveRandomlyBehavior.getCommand(time);
+    Command secondCommand = moveRandomlyBehavior.getCommand(time, environmentModel);
 
     // We return the first selection until after selectionValidFor so the commands should be identical
     ASSERT_EQ(firstCommand.nextDirection(), secondCommand.nextDirection());
@@ -39,7 +39,7 @@ TEST(MoveRandomlyTest, getRandomCommand) {
         {Direction::UP, 0}, {Direction::DOWN, 0}, {Direction::LEFT, 0}, {Direction::RIGHT, 0}};
 
     for (int i = 0; i < sampleSize; i++) {
-        Direction direction = moveRandomlyBehavior.getCommand(time).nextDirection();
+        Direction direction = moveRandomlyBehavior.getCommand(time, environmentModel).nextDirection();
         directionCounter[direction]++;
 
         // We need to progress time to force a re-selection of a new direction

--- a/demo/test/move_randomly_behavior.cpp
+++ b/demo/test/move_randomly_behavior.cpp
@@ -2,20 +2,23 @@
 
 #include <gtest/gtest.h>
 
+#include "mock_environment_model.hpp"
+
 namespace demo {
 
 TEST(MoveRandomlyTest, checkInvocationConditionTrue) {
     MoveRandomlyBehavior moveRandomlyBehavior(MoveRandomlyBehavior::Parameters{});
-    ASSERT_TRUE(moveRandomlyBehavior.checkInvocationCondition(Clock::now()));
+    ASSERT_TRUE(moveRandomlyBehavior.checkInvocationCondition(Clock::now(), MockEnvironmentModel()));
 }
 
 TEST(MoveRandomlyTest, checkCommitmentConditionFalse) {
     MoveRandomlyBehavior moveRandomlyBehavior(MoveRandomlyBehavior::Parameters{});
-    ASSERT_FALSE(moveRandomlyBehavior.checkCommitmentCondition(Clock::now()));
+    ASSERT_FALSE(moveRandomlyBehavior.checkCommitmentCondition(Clock::now(), MockEnvironmentModel()));
 }
 
 TEST(MoveRandomlyTest, getCachedCommand) {
     Duration selectionValidFor{std::chrono::seconds(1)};
+    MockEnvironmentModel environmentModel;
     MoveRandomlyBehavior moveRandomlyBehavior(MoveRandomlyBehavior::Parameters{selectionValidFor});
 
     Time time = Clock::now();
@@ -30,6 +33,7 @@ TEST(MoveRandomlyTest, getCachedCommand) {
 
 TEST(MoveRandomlyTest, getRandomCommand) {
     Duration selectionValidFor{std::chrono::seconds(1)};
+    MockEnvironmentModel environmentModel{};
     MoveRandomlyBehavior moveRandomlyBehavior(MoveRandomlyBehavior::Parameters{selectionValidFor});
 
     Time time = Clock::now();

--- a/demo/test/stay_in_place_behavior.cpp
+++ b/demo/test/stay_in_place_behavior.cpp
@@ -9,40 +9,35 @@ namespace demo {
 
 class StayInPlaceBehaviorTest : public ::testing::Test {
 protected:
-    StayInPlaceBehaviorTest()
-            : environmentModel_(std::make_shared<MockEnvironmentModel>()), stayInPlaceBehavior_{environmentModel_} {
-    }
-
-    MockEnvironmentModel::Ptr environmentModel_;
-
-    StayInPlaceBehavior stayInPlaceBehavior_;
+    MockEnvironmentModel environmentModel_{};
+    StayInPlaceBehavior stayInPlaceBehavior_{};
 };
 
 TEST_F(StayInPlaceBehaviorTest, checkInvocationConditionTrue) {
-    ASSERT_TRUE(stayInPlaceBehavior_.checkInvocationCondition(Clock::now()));
+    ASSERT_TRUE(stayInPlaceBehavior_.checkInvocationCondition(Clock::now(), environmentModel_));
 }
 
 TEST_F(StayInPlaceBehaviorTest, checkCommitmentConditionFalse) {
-    ASSERT_FALSE(stayInPlaceBehavior_.checkCommitmentCondition(Clock::now()));
+    ASSERT_FALSE(stayInPlaceBehavior_.checkCommitmentCondition(Clock::now(), environmentModel_));
 }
 
 TEST_F(StayInPlaceBehaviorTest, getCommand) {
     Time time = Clock::now();
 
-    environmentModel_->setPacmanDirection(Direction::LEFT);
-    Command command = stayInPlaceBehavior_.getCommand(time, environmentModel);
+    environmentModel_.setPacmanDirection(Direction::LEFT);
+    Command command = stayInPlaceBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 
-    environmentModel_->setPacmanDirection(Direction::RIGHT);
-    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
+    environmentModel_.setPacmanDirection(Direction::RIGHT);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 
-    environmentModel_->setPacmanDirection(Direction::UP);
-    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
+    environmentModel_.setPacmanDirection(Direction::UP);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 
-    environmentModel_->setPacmanDirection(Direction::DOWN);
-    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
+    environmentModel_.setPacmanDirection(Direction::DOWN);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel_);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/stay_in_place_behavior.cpp
+++ b/demo/test/stay_in_place_behavior.cpp
@@ -30,19 +30,19 @@ TEST_F(StayInPlaceBehaviorTest, getCommand) {
     Time time = Clock::now();
 
     environmentModel_->setPacmanDirection(Direction::LEFT);
-    Command command = stayInPlaceBehavior_.getCommand(time);
+    Command command = stayInPlaceBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::RIGHT);
 
     environmentModel_->setPacmanDirection(Direction::RIGHT);
-    command = stayInPlaceBehavior_.getCommand(time);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::LEFT);
 
     environmentModel_->setPacmanDirection(Direction::UP);
-    command = stayInPlaceBehavior_.getCommand(time);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::DOWN);
 
     environmentModel_->setPacmanDirection(Direction::DOWN);
-    command = stayInPlaceBehavior_.getCommand(time);
+    command = stayInPlaceBehavior_.getCommand(time, environmentModel);
     ASSERT_EQ(command.nextDirection(), Direction::UP);
 }
 

--- a/demo/test/verifier.cpp
+++ b/demo/test/verifier.cpp
@@ -58,9 +58,9 @@ TEST_F(VerifierTest, verifierInPriorityArbitrator) {
     ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time));
 
     testPriorityArbitrator.gainControl(time);
-    testPriorityArbitrator.getCommand(time);
+    testPriorityArbitrator.getCommand(time, environmentModel);
 
-    const auto yaml = testPriorityArbitrator.toYaml(time);
+    const auto yaml = testPriorityArbitrator.toYaml(time, environmentModel);
     ASSERT_EQ(true, yaml["activeBehavior"].IsDefined());
     EXPECT_EQ(3, yaml["activeBehavior"].as<int>());
     EXPECT_FALSE(testPriorityArbitrator.options().at(0)->verificationResult_.cached(time));
@@ -97,7 +97,7 @@ TEST_F(VerifierTest, verifierInPriorityArbitrator) {
 
     testPriorityArbitrator.gainControl(time);
 
-    EXPECT_THROW(testPriorityArbitrator.getCommand(time),
+    EXPECT_THROW(testPriorityArbitrator.getCommand(time, environmentModel),
                  arbitration_graphs::NoApplicableOptionPassedVerificationError);
 }
 

--- a/demo/test/verifier.cpp
+++ b/demo/test/verifier.cpp
@@ -19,6 +19,8 @@ protected:
                             "###"};
         environmentModel.setMaze({3, 3}, str);
         environmentModel.setPacmanPosition({1, 1});
+
+        verifier = std::make_shared<Verifier>();
     }
 
     Command goodCommand{Direction::RIGHT};

--- a/demo/test/verifier.cpp
+++ b/demo/test/verifier.cpp
@@ -13,15 +13,12 @@ class VerifierTest : public ::testing::Test {
 protected:
     using AbstractResult = arbitration_graphs::verification::AbstractResult;
 
-    VerifierTest()
-            : environmentModel(std::make_shared<MockEnvironmentModel>()),
-              verifier(std::make_shared<Verifier>(environmentModel)) {
-
+    VerifierTest() {
         const char str[] = {"###"
                             "#  "
                             "###"};
-        environmentModel->setMaze({3, 3}, str);
-        environmentModel->setPacmanPosition({1, 1});
+        environmentModel.setMaze({3, 3}, str);
+        environmentModel.setPacmanPosition({1, 1});
     }
 
     Command goodCommand{Direction::RIGHT};
@@ -32,21 +29,21 @@ protected:
         std::make_shared<DummyBehavior>(true, false, badCommand, "MidPriority");
     DummyBehavior::Ptr testBehaviorLowPriority =
         std::make_shared<DummyBehavior>(true, true, goodCommand, "LowPriority");
-    MockEnvironmentModel::Ptr environmentModel;
+    MockEnvironmentModel environmentModel;
     Time time{Clock::now()};
     Verifier::Ptr verifier;
 };
 
 TEST_F(VerifierTest, basicVerification) {
-    AbstractResult::Ptr goodResult = verifier->analyze(time, goodCommand);
+    AbstractResult::Ptr goodResult = verifier->analyze(time, environmentModel, goodCommand);
     EXPECT_TRUE(goodResult->isOk());
 
-    AbstractResult::Ptr badResult = verifier->analyze(time, badCommand);
+    AbstractResult::Ptr badResult = verifier->analyze(time, environmentModel, badCommand);
     EXPECT_FALSE(badResult->isOk());
 }
 
 TEST_F(VerifierTest, verifierInPriorityArbitrator) {
-    using PriorityArbitrator = arbitration_graphs::PriorityArbitrator<Command, Command>;
+    using PriorityArbitrator = arbitration_graphs::PriorityArbitrator<EnvironmentModel, Command>;
 
     PriorityArbitrator testPriorityArbitrator("PriorityArbitrator", verifier);
 
@@ -55,9 +52,9 @@ TEST_F(VerifierTest, verifierInPriorityArbitrator) {
     testPriorityArbitrator.addOption(testBehaviorMidPriority, PriorityArbitrator::Option::Flags::NO_FLAGS);
     testPriorityArbitrator.addOption(testBehaviorLowPriority, PriorityArbitrator::Option::Flags::NO_FLAGS);
 
-    ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time));
+    ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time, environmentModel));
 
-    testPriorityArbitrator.gainControl(time);
+    testPriorityArbitrator.gainControl(time, environmentModel);
     testPriorityArbitrator.getCommand(time, environmentModel);
 
     const auto yaml = testPriorityArbitrator.toYaml(time, environmentModel);
@@ -85,17 +82,17 @@ TEST_F(VerifierTest, verifierInPriorityArbitrator) {
                                   + strikeThroughOff + "\n"
                         " -> 4. " + invocationTrueString + commitmentTrueString + "LowPriority";
     // clang-format on
-    std::string actualPrintout = testPriorityArbitrator.to_str(time);
+    std::string actualPrintout = testPriorityArbitrator.to_str(time, environmentModel);
     std::cout << actualPrintout << std::endl;
 
     EXPECT_EQ(expectedPrintout, actualPrintout);
 
-    testPriorityArbitrator.loseControl(time);
+    testPriorityArbitrator.loseControl(time, environmentModel);
 
     testBehaviorLowPriority->invocationCondition_ = false;
-    ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time));
+    ASSERT_TRUE(testPriorityArbitrator.checkInvocationCondition(time, environmentModel));
 
-    testPriorityArbitrator.gainControl(time);
+    testPriorityArbitrator.gainControl(time, environmentModel);
 
     EXPECT_THROW(testPriorityArbitrator.getCommand(time, environmentModel),
                  arbitration_graphs::NoApplicableOptionPassedVerificationError);

--- a/docs/tasks/1_implement_behavior_component.md
+++ b/docs/tasks/1_implement_behavior_component.md
@@ -50,7 +50,7 @@ Finish the implementation of the `checkInvocationCondition()` and `getCommand()`
 
 Fix the invocation condition in `src/chase_ghost_behavior.cpp`:
 ```cpp
-bool ChaseGhostBehavior::checkInvocationCondition(const Time& time) const {
+bool ChaseGhostBehavior::checkInvocationCondition(const Time& time, const EnvironmentModel& environmentModel) const {
     return environmentModel_->closestScaredGhost(time).has_value() &&
            environmentModel_->closestScaredGhost(time)->ghost.scaredCountdown > parameters_.minScaredTicksLeft &&
            environmentModel_->closestScaredGhost(time)->distance < parameters_.invocationMinDistance; // Only applicable if a ghost is close by
@@ -59,7 +59,7 @@ bool ChaseGhostBehavior::checkInvocationCondition(const Time& time) const {
 
 Add the missing piece of the `getCommand()` function in `src/chase_ghost_behavior.cpp`:
 ```cpp
-Command ChaseGhostBehavior::getCommand(const Time& time) {
+Command ChaseGhostBehavior::getCommand(const Time& time, const EnvironmentModel& environmentModel) {
     auto pacmanPosition = environmentModel_->pacmanPosition();
 
     auto closestScaredGhost = environmentModel_->closestScaredGhost(time);


### PR DESCRIPTION
This builds upon #131 to move the environment model into the main interfaces of the arbitration graph library.
Instead of passing a shared pointer to the environment model to the behavior components, we now store one single instance in the main class (the `PacmanAgent`) and pass references to it when calling `getCommand`. 