### PR TITLE
Update README.md after closing #123

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ It's based on this demo and guides you through all important concepts:
 
 ## Installation
 
-> **Note:** We are currently working on a new major release of the library which will include some breaking changes.
-> See the corresponding [issue](https://github.com/KIT-MRT/arbitration_graphs/issues/116) and [pull request](https://github.com/KIT-MRT/arbitration_graphs/pull/123) for details and the current status.
-
 The `arbitration_graphs` library consists of two parts
 - **Core**  
   This is what it's all about – base classes for arbitrators and behavior components, implementations of various arbitration schemes, behavior verification, …


### PR DESCRIPTION
After finishing the breaking interface changes in #123, we can remove the pre-warning hint from the Readme again.

#patch